### PR TITLE
Optimized the system tray function

### DIFF
--- a/assets/ArkPetsConfigDefault.json
+++ b/assets/ArkPetsConfigDefault.json
@@ -18,7 +18,5 @@
     "physic_gravity_acc":800.0,
     "physic_speed_limit_x":1000.0,
     "physic_speed_limit_y":1000.0,
-    "physic_static_friction_acc":500.0,
-    "server_port": 8080,
-    "separate_arkpet_from_launcher": false
+    "physic_static_friction_acc":500.0
 }

--- a/core/src/cn/harryh/arkpets/ArkConfig.java
+++ b/core/src/cn/harryh/arkpets/ArkConfig.java
@@ -63,8 +63,6 @@ public class ArkConfig {
     public float      physic_static_friction_acc;
     public float      physic_speed_limit_x;
     public float      physic_speed_limit_y;
-    public int        server_port = 8080;
-    public boolean    separate_arkpet_from_launcher;
 
     private ArkConfig() {
     }

--- a/core/src/cn/harryh/arkpets/ArkPets.java
+++ b/core/src/cn/harryh/arkpets/ArkPets.java
@@ -88,7 +88,7 @@ public class ArkPets extends ApplicationAdapter implements InputProcessor {
 		ArkConfig.Monitor primaryMonitor = ArkConfig.Monitor.getMonitors()[0];
 		initWindow((int)(primaryMonitor.size[0] * 0.1f), (int)(primaryMonitor.size[0] * 0.1f));
 		// 5.Tray icon setup
-		tray = new ArkTray(this, new SocketClient(config.server_port), UUID.randomUUID());
+		tray = new ArkTray(this, new SocketClient(), UUID.randomUUID());
 		// Setup complete
 		Logger.info("App", "Render");
 	}
@@ -142,7 +142,6 @@ public class ArkPets extends ApplicationAdapter implements InputProcessor {
 	@Override
 	public void dispose() {
 		Logger.info("App", "Dispose");
-		tray.removeTray();
 	}
 
 	public boolean canChangeStage() {

--- a/core/src/cn/harryh/arkpets/ArkTray.java
+++ b/core/src/cn/harryh/arkpets/ArkTray.java
@@ -12,14 +12,17 @@ import com.badlogic.gdx.Gdx;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.UUID;
 
-import static cn.harryh.arkpets.Const.fontFileRegular;
-import static cn.harryh.arkpets.Const.linearEasingDuration;
+import static cn.harryh.arkpets.Const.*;
 
 
 public class ArkTray extends Tray {
@@ -65,7 +68,25 @@ public class ArkTray extends Tray {
         };
         name = (arkPets.config.character_label == null || arkPets.config.character_label.isEmpty()) ? "Unknown" : arkPets.config.character_label;
         socketClient.connect(socketData -> {
-            if (socketData == null || socketData.uuid.compareTo(uuid) != 0)
+            if (socketData == null) {
+                Image image = Toolkit.getDefaultToolkit().createImage(getClass().getResource(iconFilePng));
+                TrayIcon icon = getTrayIcon(image);
+
+                // Add the icon to the system tray.
+                try {
+                    SystemTray.getSystemTray().add(icon);
+                    Logger.info("Tray", "Tray icon applied");
+                } catch (AWTException e) {
+                    Logger.error("Tray", "Unable to apply tray icon, details see below", e);
+                }
+                socketClient.disconnect();
+                socketClient.reconnect(() -> {
+                    SystemTray.getSystemTray().remove(icon);
+                    socketClient.sendRequest(new SocketData(this.uuid, SocketData.OperateType.LOGIN, name, arkPets.canChangeStage()));
+                });
+                return;
+            }
+            if (socketData.uuid.compareTo(uuid) != 0)
                 return;
             switch (socketData.operateType) {
                 case LOGOUT -> optExitHandler();
@@ -80,6 +101,22 @@ public class ArkTray extends Tray {
         addComponent();
     }
 
+    private TrayIcon getTrayIcon(Image image) {
+        TrayIcon icon = new TrayIcon(image, name);
+        icon.setImageAutoSize(true);
+        icon.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.getButton() == 3 && e.isPopupTrigger()) {
+                    // After right-click on the tray icon.
+                    int x = e.getX();
+                    int y = e.getY();
+                    showDialog(x + 5, y);
+                }
+            }
+        });
+        return icon;
+    }
 
     @Override
     protected void addComponent() {
@@ -109,11 +146,12 @@ public class ArkTray extends Tray {
         Logger.info("Tray", "Request to exit");
         arkPets.windowAlpha.reset(0f);
         removeTray();
-        try {
-            Thread.sleep((long) (linearEasingDuration * 1000));
-            Gdx.app.exit();
-        } catch (InterruptedException ignored) {
-        }
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                Gdx.app.exit();
+            }
+        }, (int) (linearEasingDuration * 1000));
     }
 
     @Override

--- a/core/src/cn/harryh/arkpets/ArkTray.java
+++ b/core/src/cn/harryh/arkpets/ArkTray.java
@@ -32,6 +32,7 @@ public class ArkTray extends Tray {
     public static Font font;
     private final JDialog popWindow;
     private final JPopupMenu popMenu;
+    private final boolean[] button = {false, false};
 
     static {
         try {
@@ -83,6 +84,12 @@ public class ArkTray extends Tray {
                 socketClient.reconnect(() -> {
                     SystemTray.getSystemTray().remove(icon);
                     socketClient.sendRequest(new SocketData(this.uuid, SocketData.OperateType.LOGIN, name, arkPets.canChangeStage()));
+                    if (button[0]) {
+                        socketClient.sendRequest(new SocketData(this.uuid, SocketData.OperateType.KEEP_ACTION));
+                    }
+                    if (button[1]) {
+                        socketClient.sendRequest(new SocketData(this.uuid, SocketData.OperateType.TRANSPARENT_MODE));
+                    }
                 });
                 return;
             }
@@ -168,6 +175,7 @@ public class ArkTray extends Tray {
     @Override
     protected void optTransparentDisHandler() {
         Logger.info("Tray", "Transparent disabled");
+        button[1] = false;
         arkPets.windowAlpha.reset(1f);
         arkPets.hWndMine.setWindowTransparent(false);
         popMenu.remove(optTransparentDis);
@@ -177,6 +185,7 @@ public class ArkTray extends Tray {
     @Override
     protected void optTransparentEnHandler() {
         Logger.info("Tray", "Transparent enabled");
+        button[1] = true;
         arkPets.windowAlpha.reset(0.75f);
         arkPets.hWndMine.setWindowTransparent(true);
         popMenu.remove(optTransparentEn);
@@ -186,6 +195,7 @@ public class ArkTray extends Tray {
     @Override
     protected void optKeepAnimDisHandler() {
         Logger.info("Tray", "Keep-Anim disabled");
+        button[0] = false;
         keepAnim = null;
         popMenu.remove(optKeepAnimDis);
         popMenu.add(optKeepAnimEn, 1);
@@ -194,6 +204,7 @@ public class ArkTray extends Tray {
     @Override
     protected void optKeepAnimEnHandler() {
         Logger.info("Tray", "Keep-Anim enabled");
+        button[0] = true;
         keepAnim = arkPets.cha.getPlaying();
         popMenu.remove(optKeepAnimEn);
         popMenu.add(optKeepAnimDis, 1);

--- a/core/src/cn/harryh/arkpets/Const.java
+++ b/core/src/cn/harryh/arkpets/Const.java
@@ -103,4 +103,8 @@ public final class Const {
         public static final String debugArg = "--debug";
     }
 
+    // SocketServer Ports
+
+    public static final int[] serverPorts = {8686, 8866, 8989, 8899, 8800};
+
 }

--- a/core/src/cn/harryh/arkpets/exception/NoPortAvailableException.java
+++ b/core/src/cn/harryh/arkpets/exception/NoPortAvailableException.java
@@ -1,0 +1,7 @@
+package cn.harryh.arkpets.exception;
+
+public class NoPortAvailableException extends Exception {
+    public NoPortAvailableException() {
+        super("No port available");
+    }
+}

--- a/core/src/cn/harryh/arkpets/exception/NoServerRunningException.java
+++ b/core/src/cn/harryh/arkpets/exception/NoServerRunningException.java
@@ -1,0 +1,7 @@
+package cn.harryh.arkpets.exception;
+
+public class NoServerRunningException extends Exception {
+    public NoServerRunningException() {
+        super("Can not find a running server");
+    }
+}

--- a/core/src/cn/harryh/arkpets/exception/ServerRunningException.java
+++ b/core/src/cn/harryh/arkpets/exception/ServerRunningException.java
@@ -1,0 +1,7 @@
+package cn.harryh.arkpets.exception;
+
+public class ServerRunningException extends Exception {
+    public ServerRunningException() {
+        super("Server is already running");
+    }
+}

--- a/core/src/cn/harryh/arkpets/process_pool/ProcessPool.java
+++ b/core/src/cn/harryh/arkpets/process_pool/ProcessPool.java
@@ -1,20 +1,30 @@
 package cn.harryh.arkpets.process_pool;
 
+import cn.harryh.arkpets.socket.InteriorSocketServer;
+
 import java.io.File;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
 
 public class ProcessPool {
     private final Set<ProcessHolder> processHolderHashSet = new HashSet<>();
-    private final java.util.concurrent.ExecutorService executorService;
+    private final java.util.concurrent.ExecutorService executorService = InteriorSocketServer.getThreadPool();
+    private static ProcessPool instance = null;
 
-    public ProcessPool() {
-        this.executorService = Executors.newFixedThreadPool(10);
+    public static ProcessPool getInstance() {
+        if (instance == null)
+            instance = new ProcessPool();
+        return instance;
+    }
+
+    private ProcessPool() {
     }
 
     public void shutdown() {
         processHolderHashSet.forEach(processHolder -> processHolder.getProcess().destroy());
-        executorService.shutdown();
     }
 
     public Future<?> submit(Runnable task) {

--- a/core/src/cn/harryh/arkpets/process_pool/Status.java
+++ b/core/src/cn/harryh/arkpets/process_pool/Status.java
@@ -1,6 +1,0 @@
-package cn.harryh.arkpets.process_pool;
-
-public enum Status {
-    SUCCESS,
-    FAILURE
-}

--- a/core/src/cn/harryh/arkpets/process_pool/TaskStatus.java
+++ b/core/src/cn/harryh/arkpets/process_pool/TaskStatus.java
@@ -1,6 +1,12 @@
 package cn.harryh.arkpets.process_pool;
 
 public class TaskStatus {
+
+    public enum Status {
+        SUCCESS,
+        FAILURE
+    }
+
     private final Status status;
     private final Throwable exception;
     private final Long processId;

--- a/core/src/cn/harryh/arkpets/socket/SocketClient.java
+++ b/core/src/cn/harryh/arkpets/socket/SocketClient.java
@@ -1,5 +1,6 @@
 package cn.harryh.arkpets.socket;
 
+import cn.harryh.arkpets.exception.NoServerRunningException;
 import cn.harryh.arkpets.utils.Logger;
 import com.alibaba.fastjson2.JSONObject;
 
@@ -8,27 +9,63 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.net.SocketException;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.function.Consumer;
 
+import static cn.harryh.arkpets.utils.IOUtils.NetUtils.getServerPort;
+
+
 public class SocketClient {
-    private final String host;
-    private final int port;
+    private class Task extends TimerTask {
+
+        private final Runnable callback;
+
+        public Task(Runnable callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Logger.info("Socket", "Searching server");
+                port = getServerPort();
+                Logger.info("Socket", "Server found, connecting");
+                timer.cancel();
+                receiveThreadBreakFlag = false;
+                connect(consumer);
+                callback.run();
+            } catch (NoServerRunningException ignored) {
+            }
+        }
+    }
+
+    private final static String host = "localhost";
+    private int port;
     private boolean connected = false;
     private Socket socket;
     private PrintWriter socketOut;
     private BufferedReader socketIn;
+    private Thread thread = null;
+    private Timer timer;
+    private Consumer<SocketData> consumer;
     private volatile boolean receiveThreadBreakFlag = false;
 
-    public SocketClient(String host, int port) {
-        this.host = host;
-        this.port = port;
+    public SocketClient() {
+        try {
+            port = getServerPort();
+        } catch (NoServerRunningException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public void reconnect(Runnable callback) {
+        timer = new Timer();
+        timer.schedule(new Task(callback), 0, 5000);
     }
 
-    public SocketClient(int port) {
-        this("localhost", port);
-    }
-
-    public void connect(Consumer<SocketData> consumer) {
+    public void connect() {
         if (connected) {
             return;
         }
@@ -36,22 +73,31 @@ public class SocketClient {
             socket = new Socket(host, port);
             socketOut = new PrintWriter(socket.getOutputStream(), true);
             socketIn = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-            Thread thread = new Thread(() -> {
-                while (!receiveThreadBreakFlag) {
-                    try {
-                        consumer.accept(JSONObject.parseObject(socketIn.readLine(), SocketData.class));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            });
-            thread.setDaemon(true);
-            thread.start();
             connected = true;
         } catch (IOException e) {
             Logger.error("Socket", "Error connecting to %s:%d".formatted(host, port));
             throw new RuntimeException(e);
         }
+    }
+
+    public void connect(Consumer<SocketData> consumer) {
+        connect();
+        this.consumer = consumer;
+        thread = new Thread(() -> {
+            while (!receiveThreadBreakFlag) {
+                try {
+                    String receive = socketIn.readLine();
+                    Logger.debug("Socket", receive);
+                    consumer.accept(JSONObject.parseObject(receive, SocketData.class));
+                } catch (SocketException e) {
+                    consumer.accept(null);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
     }
 
     public void disconnect() {
@@ -60,6 +106,8 @@ public class SocketClient {
         }
         receiveThreadBreakFlag = true;
         try {
+            if (thread != null)
+                thread.interrupt();
             socket.close();
             socketOut.close();
             socketIn.close();

--- a/core/src/cn/harryh/arkpets/socket/SocketData.java
+++ b/core/src/cn/harryh/arkpets/socket/SocketData.java
@@ -2,6 +2,7 @@ package cn.harryh.arkpets.socket;
 
 import java.util.UUID;
 
+
 public class SocketData {
     public enum OperateType {
         LOGIN,
@@ -10,7 +11,10 @@ public class SocketData {
         NO_KEEP_ACTION,
         TRANSPARENT_MODE,
         NO_TRANSPARENT_MODE,
-        CHANGE_STAGE
+        CHANGE_STAGE,
+        VERIFY,
+        SERVER_ONLINE,
+        ACTIVATE_LAUNCHER
     }
 
     public UUID uuid;

--- a/core/src/cn/harryh/arkpets/tray/SystemTrayManager.java
+++ b/core/src/cn/harryh/arkpets/tray/SystemTrayManager.java
@@ -14,11 +14,13 @@ import java.util.UUID;
 
 import static cn.harryh.arkpets.Const.iconFilePng;
 
+
 public class SystemTrayManager extends TrayManager {
     private static SystemTrayManager instance = null;
     private volatile JPopupMenu popupMenu;
     private volatile JDialog popWindow;
     private volatile JMenu playerMenu;
+    private static Stage stage;
     private static double x = 0;
     private static double y = 0;
 
@@ -96,13 +98,14 @@ public class SystemTrayManager extends TrayManager {
     public void listen(Stage stage) {
         if (!initialized)
             return;
+        SystemTrayManager.stage = stage;
         trayIcon.removeMouseListener(new MouseAdapter() {
         });
         MouseListener mouseListener = new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
-                    showStage(stage);
+                    showStage();
                 }
             }
         };
@@ -112,7 +115,7 @@ public class SystemTrayManager extends TrayManager {
     }
 
     @Override
-    public void hide(Stage stage) {
+    public void hide() {
         if (!initialized)
             return;
         Platform.runLater(() -> {
@@ -126,7 +129,7 @@ public class SystemTrayManager extends TrayManager {
         });
     }
 
-    private void showStage(Stage stage) {
+    private void showStage() {
         if (!initialized)
             return;
         Platform.runLater(() -> {
@@ -142,9 +145,14 @@ public class SystemTrayManager extends TrayManager {
         });
     }
 
+    public void showLauncher() {
+        showStage();
+    }
+
     @Override
     public void addTray(UUID uuid, Tray tray) {
         arkPetTrays.put(uuid, tray);
+//        sendInfoMessage("新桌宠连接", "%s", tray.getName());
     }
 
     @Override

--- a/core/src/cn/harryh/arkpets/tray/Tray.java
+++ b/core/src/cn/harryh/arkpets/tray/Tray.java
@@ -3,6 +3,7 @@ package cn.harryh.arkpets.tray;
 import javax.swing.*;
 import java.util.UUID;
 
+
 public abstract class Tray {
     protected JMenuItem optKeepAnimEn = new JMenuItem("保持动作");
     protected JMenuItem optKeepAnimDis = new JMenuItem("取消保持");
@@ -24,6 +25,10 @@ public abstract class Tray {
         optExit.addActionListener(e -> optExitHandler());
     }
 
+    public String getName() {
+        return name;
+    }
+
     protected abstract void addComponent();
 
     protected abstract void optExitHandler();
@@ -37,5 +42,6 @@ public abstract class Tray {
     protected abstract void optKeepAnimDisHandler();
 
     protected abstract void optKeepAnimEnHandler();
+
     public abstract void removeTray();
 }

--- a/core/src/cn/harryh/arkpets/tray/TrayManager.java
+++ b/core/src/cn/harryh/arkpets/tray/TrayManager.java
@@ -1,8 +1,6 @@
 package cn.harryh.arkpets.tray;
 
 import cn.harryh.arkpets.ArkTray;
-import cn.harryh.arkpets.process_pool.ProcessPool;
-import cn.harryh.arkpets.process_pool.TaskStatus;
 import cn.harryh.arkpets.utils.Logger;
 import javafx.stage.Stage;
 
@@ -10,17 +8,16 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.*;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 import static cn.harryh.arkpets.Const.fontFileRegular;
 
 public abstract class TrayManager {
     protected volatile SystemTray tray;
     protected volatile TrayIcon trayIcon;
-    protected final static ProcessPool processPool = new ProcessPool();
     protected boolean initialized = false;
     protected Map<UUID, Tray> arkPetTrays = new HashMap<>();
     public static Font font;
@@ -43,7 +40,7 @@ public abstract class TrayManager {
 
     public abstract void listen(Stage stage);
 
-    public abstract void hide(Stage stage);
+    public abstract void hide();
 
     public abstract void addTray(UUID uuid, Tray tray);
 
@@ -51,14 +48,18 @@ public abstract class TrayManager {
 
     public abstract Tray getTray(UUID uuid);
 
-    public void shutdown() {
-        processPool.shutdown();
-    }
 
     public SystemTray getTray() {
         return tray;
     }
 
+    /**
+     * Send system tray information
+     * @param messageType info type
+     * @param title title
+     * @param content content
+     * @param args content args
+     */
     private void sendMessage(TrayIcon.MessageType messageType, String title, String content, Object... args) {
         if (!initialized)
             return;
@@ -79,13 +80,5 @@ public abstract class TrayManager {
 
     public void sendMessage(String title, String content, Object... args) {
         sendMessage(TrayIcon.MessageType.NONE, title, content, args);
-    }
-
-    public FutureTask<TaskStatus> submit(Class<?> clazz, java.util.List<String> jvmArgs, List<String> args) {
-        return processPool.submit(clazz, jvmArgs, args);
-    }
-
-    public Future<?> submit(Runnable task) {
-        return processPool.submit(task);
     }
 }

--- a/desktop/src/cn/harryh/arkpets/DesktopLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/DesktopLauncher.java
@@ -3,7 +3,7 @@
  */
 package cn.harryh.arkpets;
 
-import cn.harryh.arkpets.tray.SystemTrayManager;
+import cn.harryh.arkpets.process_pool.ProcessPool;
 import cn.harryh.arkpets.utils.ArgPending;
 import cn.harryh.arkpets.utils.Logger;
 import javafx.application.Application;
@@ -62,7 +62,7 @@ public class DesktopLauncher {
         };
 
         // Java FX bootstrap
-        Future<?> future = SystemTrayManager.getInstance().submit(() -> Application.launch(ArkHomeFX.class, args));
+        Future<?> future = ProcessPool.getInstance().submit(() -> Application.launch(ArkHomeFX.class, args));
         try {
             future.get();
         } catch (InterruptedException | ExecutionException e) {

--- a/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
@@ -8,9 +8,8 @@ import cn.harryh.arkpets.ArkHomeFX;
 import cn.harryh.arkpets.EmbeddedLauncher;
 import cn.harryh.arkpets.guitasks.CheckAppUpdateTask;
 import cn.harryh.arkpets.guitasks.GuiTask;
-import cn.harryh.arkpets.process_pool.Status;
+import cn.harryh.arkpets.process_pool.ProcessPool;
 import cn.harryh.arkpets.process_pool.TaskStatus;
-import cn.harryh.arkpets.tray.SystemTrayManager;
 import cn.harryh.arkpets.utils.ArgPending;
 import cn.harryh.arkpets.utils.GuiPrefabs;
 import cn.harryh.arkpets.utils.JavaProcess;
@@ -147,9 +146,9 @@ public final class RootModule implements Controller<ArkHomeFX> {
                 // Start ArkPets core.
                 Logger.info("Launcher", "Launching " + app.config.character_asset);
                 Logger.debug("Launcher", "With args " + args);
-                FutureTask<TaskStatus> future = SystemTrayManager.getInstance().submit(EmbeddedLauncher.class, List.of(), args);
+                FutureTask<TaskStatus> future = ProcessPool.getInstance().submit(EmbeddedLauncher.class, List.of(), args);
                 // ArkPets core finalized.
-                if (Objects.equals(future.get().getStatus(), Status.FAILURE)) {
+                if (Objects.equals(future.get().getStatus(), TaskStatus.Status.FAILURE)) {
                     Logger.warn("Launcher", "Detected an abnormal finalization of an ArkPets thread (exit code -1). Please check the log file for details.");
                     lastLaunchFailed = new JavaProcess.UnexpectedExitCodeException(-1);
                     return false;


### PR DESCRIPTION
实现了 #59 里面的补充内容。

额外实现：
现在如果启动器异常退出（或者手动退出），桌宠会从集中管理（简称托管模式）退回到“一个本体一个托盘”的模式（简称托盘模式），同时会每隔5秒扫描一次端口列表，如果发现服务器，则会发起连接请求，回到托管模式。

https://github.com/isHarryh/Ark-Pets/assets/50048293/88f7d830-39eb-46e6-87cb-d6f8c1d1bc6b

PS: 录着视频给我发现个bug，~~mmp~~