### PR TITLE
Fixed crash cuased by loading json skeleton

### DIFF
--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -80,10 +80,10 @@ public class ArkChar {
                 binary.setScale(scale);
                 skeletonData = binary.readSkeletonData(Gdx.files.internal(path2skel));
             } catch (Exception e) {
-                Logger.warn("Character", "Failed to load skeleton,trying load as json");
-                SkeletonJson json=new SkeletonJson(atlas);
+                Logger.warn("Character", "Failed to load skeleton, trying load as json");
+                SkeletonJson json = new SkeletonJson(atlas);
                 json.setScale(scale);
-                skeletonData=json.readSkeletonData(Gdx.files.internal(path2skel));
+                skeletonData = json.readSkeletonData(Gdx.files.internal(path2skel));
             }
         } catch (SerializationException | GdxRuntimeException e) {
             Logger.error("Character", "The model asset may be inaccessible, details see below.", e);

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -75,9 +75,16 @@ public class ArkChar {
             // Load atlas
             TextureAtlas atlas = new TextureAtlas(Gdx.files.internal(path2atlas));
             // Load skel (use SkeletonJson instead of SkeletonBinary if the file type is JSON)
-            SkeletonBinary binary = new SkeletonBinary(atlas);
-            binary.setScale(scale);
-            skeletonData = binary.readSkeletonData(Gdx.files.internal(path2skel));
+            try {
+                SkeletonBinary binary = new SkeletonBinary(atlas);
+                binary.setScale(scale);
+                skeletonData = binary.readSkeletonData(Gdx.files.internal(path2skel));
+            } catch (Exception e) {
+                Logger.warn("Character", "Failed to load skeleton,trying load as json");
+                SkeletonJson json=new SkeletonJson(atlas);
+                json.setScale(scale);
+                skeletonData=json.readSkeletonData(Gdx.files.internal(path2skel));
+            }
         } catch (SerializationException | GdxRuntimeException e) {
             Logger.error("Character", "The model asset may be inaccessible, details see below.", e);
             throw new RuntimeException("Launch ArkPets failed, the model asset may be inaccessible.");


### PR DESCRIPTION
在尝试以二进制加载 skel 文件失败时，转为以 JSON 方式加载。
效果：
![Screenshot from 2024-09-01 18-10-11](https://github.com/user-attachments/assets/1d664dfe-ce7b-4711-8e0d-a4d16944a2db)
