### PR TITLE
Cross-platform support and minor features

### DIFF
--- a/assets/ArkPetsConfigDefault.json
+++ b/assets/ArkPetsConfigDefault.json
@@ -1,4 +1,5 @@
 {
+    "background_color":"#00000000",
     "behavior_ai_activation":8,
     "behavior_allow_interact":true,
     "behavior_allow_sit":true,

--- a/assets/ArkPetsConfigDefault.json
+++ b/assets/ArkPetsConfigDefault.json
@@ -22,5 +22,6 @@
     "physic_speed_limit_y":1000.0,
     "physic_static_friction_acc":500.0,
     "window_style_toolwindow":true,
-    "window_style_topmost":true
+    "window_style_topmost":true,
+    "window_system":0
 }

--- a/assets/UI/SettingsModule.fxml
+++ b/assets/UI/SettingsModule.fxml
@@ -35,6 +35,10 @@
                     <Label text="高亮描边"/>
                     <JFXComboBox fx:id="configRenderOutline" prefWidth="120.0"/>
                 </HBox>
+                <HBox>
+                    <Label text="背景颜色"/>
+                    <JFXComboBox fx:id="configBackgroundColor" prefWidth="120.0"/>
+                </HBox>
                 <Separator/>
                 <Label styleClass="config-group-title" text="高级设置"/>
                 <HBox>

--- a/assets/UI/SettingsModule.fxml
+++ b/assets/UI/SettingsModule.fxml
@@ -46,6 +46,11 @@
                     <JFXCheckBox fx:id="configWindowToolwindow" mnemonicParsing="false" text="桌宠作为后台程序启动"/>
                     <JFXButton fx:id="configWindowToolwindowHelp"/>
                 </HBox>
+                <HBox>
+                    <Label text="窗口系统"/>
+                    <JFXComboBox fx:id="configWindowSystem" prefWidth="100.0"/>
+                    <JFXButton fx:id="configWindowSystemHelp"/>
+                </HBox>
                 <Separator/>
                 <HBox>
                     <Label text="日志级别"/>

--- a/assets/shaders/OutlineFragment.glsl
+++ b/assets/shaders/OutlineFragment.glsl
@@ -11,6 +11,7 @@ uniform sampler2D u_texture;    // From TCPB
 uniform vec3 u_outlineColor;    // Required
 uniform float u_outlineWidth;   // Required
 uniform ivec2 u_textureSize;
+uniform float u_alpha;
 
 const float c_alphaLv0 = 0.1;
 const float c_alphaLv1 = 0.5;
@@ -77,4 +78,6 @@ void main() {
         // No effect apply on other areas
         gl_FragColor = texColor;
     }
+    // Alpha
+    gl_FragColor.a -= (1 - u_alpha);
 }

--- a/assets/shaders/OutlineFragment.glsl
+++ b/assets/shaders/OutlineFragment.glsl
@@ -4,12 +4,13 @@
 
 // Gap Seaming and Ouline Effect Fragment Shader for TwoColorPolygonBatch.
 
-#version 130
+#version 120
 
 varying vec2 v_texCoords;       // From VS
 uniform sampler2D u_texture;    // From TCPB
 uniform vec3 u_outlineColor;    // Required
 uniform float u_outlineWidth;   // Required
+uniform ivec2 u_textureSize;
 
 const float c_alphaLv0 = 0.1;
 const float c_alphaLv1 = 0.5;
@@ -31,7 +32,7 @@ vec4[8] getNeighbors(sampler2D tex, vec2 texCoords, vec2 offset) {
 
 void main() {
     vec4 texColor = texture2D(u_texture, v_texCoords);
-    ivec2 texSize = textureSize(u_texture, 0);
+    ivec2 texSize = u_textureSize;
 
     if (texColor.a < c_alphaLv0) {
         // Outline effect apply on transparent areas

--- a/assets/shaders/TCPBFragment.glsl
+++ b/assets/shaders/TCPBFragment.glsl
@@ -4,7 +4,7 @@
 
 // Common Fragment Shader for TwoColorPolygonBatch.
 
-#version 130
+#version 120
 
 #ifdef GL_ES
     #define LOWP lowp

--- a/assets/shaders/TCPBVertex.glsl
+++ b/assets/shaders/TCPBVertex.glsl
@@ -4,7 +4,7 @@
 
 // Common Vertex Shader for TwoColorPolygonBatch.
 
-#version 130
+#version 120
 
 attribute vec4 a_position;
 attribute vec4 a_light;

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ allprojects {
         gdxVersion = "1.11.0"
         jnaVersion = "5.12.1"
         javaFXVersion = "17.0.8"
+        dbusVersion = "5.0.0"
+        lwjglVersion = "3.3.4"
     }
 
     repositories {
@@ -62,15 +64,30 @@ project(":core") {
         api "net.java.dev.jna:jna:$jnaVersion"
         api "net.java.dev.jna:jna-platform:$jnaVersion"
         // JavaFX
-        api "org.openjfx:javafx-base:$javaFXVersion:win"
-        api "org.openjfx:javafx-controls:$javaFXVersion:win"
-        api "org.openjfx:javafx-graphics:$javaFXVersion:win"
-        api "org.openjfx:javafx-fxml:$javaFXVersion:win"
+        def javaFXPlatforms = ["win", "mac", "linux"]
+        javaFXPlatforms.each {
+            api "org.openjfx:javafx-base:$javaFXVersion:$it"
+            api "org.openjfx:javafx-controls:$javaFXVersion:$it"
+            api "org.openjfx:javafx-graphics:$javaFXVersion:$it"
+            api "org.openjfx:javafx-fxml:$javaFXVersion:$it"
+        }
         // JFoenix
         api "com.jfoenix:jfoenix:9.0.1"
         // FastJson
         api "com.alibaba:fastjson:2.0.39"
         // Log4j
         api "apache-log4j:log4j:1.2.15"
+        // dbus-java
+        api "com.github.hypfvieh:dbus-java-core:$dbusVersion"
+        api "com.github.hypfvieh:dbus-java-transport-native-unixsocket:$dbusVersion"
+        // LWJGL
+        def lwjglList = ["lwjgl", "lwjgl-opengl", "lwjgl-stb", "lwjgl-openal", "lwjgl-jemalloc", "lwjgl-glfw"]
+        lwjglList.each {
+            api("org.lwjgl:" + it) {
+                version {
+                    strictly lwjglVersion
+                }
+            }
+        }
     }
 }

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -62,6 +62,7 @@ public class ArkChar {
         camera.setMinInsert(canvasReserveLength - canvasMaxSize);
         batch = new TwoColorPolygonBatch();
         renderer = new SkeletonRenderer();
+        Color backgroundColor = config.getBackgroundColor();
         /* Pre-multiplied alpha shouldn't be applied to models released in Arknights 2.1.41 or later,
         otherwise you may get a corrupted rendering result. */
         renderer.setPremultipliedAlpha(false);
@@ -120,7 +121,7 @@ public class ArkChar {
             }
         };
         // 6.Canvas setup
-        setCanvas(Color.CLEAR);
+        setCanvas(backgroundColor);
         stageInsertMap = new HashMap<>();
         for (AnimStage stage : animList.clusterByStage().keySet()) {
             // Figure out the suitable canvas size

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -227,6 +227,7 @@ public class ArkChar {
         shader2.bind();
         shader2.setUniformf("u_outlineColor", 1f, 1f, 0f);
         shader2.setUniformf("u_outlineWidth", outlineWidth.now());
+        shader2.setUniformi("u_textureSize", passedTexture.getWidth(), passedTexture.getHeight());
         batch.setShader(shader2);
         ScreenUtils.clear(0, 0, 0, 0, true);
         batch.begin();

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -28,7 +28,6 @@ import com.esotericsoftware.spine.utils.TwoColorPolygonBatch;
 
 import java.util.HashMap;
 
-import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
 import static cn.harryh.arkpets.Const.*;
 import static java.io.File.separator;
 
@@ -51,6 +50,8 @@ public class ArkChar {
     private final AnimationState animationState;
     protected final AnimClipGroup animList;
     protected final HashMap<AnimStage, Insert> stageInsertMap;
+
+    protected float alpha;
 
     /** Initializes an ArkPets character.
      * @param config The ArkPets Config instance which contains the asset's information and other essential settings.
@@ -230,6 +231,7 @@ public class ArkChar {
         shader2.setUniformf("u_outlineColor", 1f, 1f, 0f);
         shader2.setUniformf("u_outlineWidth", outlineWidth.now());
         shader2.setUniformi("u_textureSize", passedTexture.getWidth(), passedTexture.getHeight());
+        shader2.setUniformf("u_alpha", alpha);
         batch.setShader(shader2);
         ScreenUtils.clear(0, 0, 0, 0, true);
         batch.begin();

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -28,6 +28,7 @@ import com.esotericsoftware.spine.utils.TwoColorPolygonBatch;
 
 import java.util.HashMap;
 
+import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
 import static cn.harryh.arkpets.Const.*;
 import static java.io.File.separator;
 
@@ -78,7 +79,7 @@ public class ArkChar {
         // 3.Skeleton setup
         SkeletonData skeletonData;
         try {
-            String assetLocation = config.character_asset;
+            String assetLocation = getWorkingDirectory() + config.character_asset;
             AssetAccessor assetAccessor = new AssetAccessor(config.character_files);
             String path2atlas = assetLocation + separator + assetAccessor.getFirstFileOf(".atlas");
             String path2skel = assetLocation + separator + assetAccessor.getFirstFileOf(".skel");

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -79,7 +79,7 @@ public class ArkChar {
         // 3.Skeleton setup
         SkeletonData skeletonData;
         try {
-            String assetLocation = getWorkingDirectory() + config.character_asset;
+            String assetLocation = config.character_asset;
             AssetAccessor assetAccessor = new AssetAccessor(config.character_files);
             String path2atlas = assetLocation + separator + assetAccessor.getFirstFileOf(".atlas");
             String path2skel = assetLocation + separator + assetAccessor.getFirstFileOf(".skel");

--- a/core/src/cn/harryh/arkpets/ArkConfig.java
+++ b/core/src/cn/harryh/arkpets/ArkConfig.java
@@ -11,6 +11,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.Color;
 
 import java.io.*;
 import java.net.URL;
@@ -38,6 +39,8 @@ public class ArkConfig implements Serializable {
 
 
     // Config items and default values:
+    /** @since ArkPets 3.4 */ @JSONField(defaultValue = "#00000000")
+    public String       background_color;
     /** @since ArkPets 1.0 */ @JSONField(defaultValue = "8")
     public int          behavior_ai_activation;
     /** @since ArkPets 1.0 */ @JSONField(defaultValue = "true")
@@ -111,6 +114,20 @@ public class ArkConfig implements Serializable {
     @JSONField(serialize = false)
     public boolean isNewcomer() {
         return isNewcomer;
+    }
+
+    /** Returns converted background color.
+     */
+    @JSONField(serialize = false)
+    public Color getBackgroundColor() {
+        Color backgroundColor;
+        try {
+            backgroundColor = Color.valueOf(background_color);
+        } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
+            Logger.warn("System", "Invalid background color,using transparent");
+            backgroundColor = Color.CLEAR;
+        }
+        return backgroundColor;
     }
 
     /** Gets the custom ArkConfig object by reading the external config file.

--- a/core/src/cn/harryh/arkpets/ArkConfig.java
+++ b/core/src/cn/harryh/arkpets/ArkConfig.java
@@ -24,7 +24,7 @@ import static cn.harryh.arkpets.Const.*;
 public class ArkConfig implements Serializable {
     public static final ArkConfig defaultConfig;
     private static final URL configDefault = Objects.requireNonNull(ArkConfig.class.getResource(Const.configInternal));
-    private static final File configCustom = new File(Const.configExternal);
+    private static final File configCustom = new File(getWorkingDirectory() + Const.configExternal);
     private static boolean isNewcomer = false;
 
     static {
@@ -128,6 +128,13 @@ public class ArkConfig implements Serializable {
             backgroundColor = Color.CLEAR;
         }
         return backgroundColor;
+    }
+
+    /** Returns working directory, ends up with separator.
+     */
+    @JSONField(serialize = false)
+    public static String getWorkingDirectory() {
+        return System.getProperty("arkpets.workdir", "");
     }
 
     /** Gets the custom ArkConfig object by reading the external config file.

--- a/core/src/cn/harryh/arkpets/ArkConfig.java
+++ b/core/src/cn/harryh/arkpets/ArkConfig.java
@@ -88,6 +88,8 @@ public class ArkConfig implements Serializable {
     public boolean      window_style_toolwindow;
     /** @since ArkPets 3.2 */ @JSONField(defaultValue = "true")
     public boolean      window_style_topmost;
+    /** @since ArkPets 3.3 */ @JSONField(defaultValue = "0")
+    public int          window_system;
 
     private ArkConfig() {
     }

--- a/core/src/cn/harryh/arkpets/ArkPets.java
+++ b/core/src/cn/harryh/arkpets/ArkPets.java
@@ -18,6 +18,7 @@ import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.graphics.GL20;
 
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +62,8 @@ public class ArkPets extends ApplicationAdapter implements InputProcessor {
 		config = Objects.requireNonNull(ArkConfig.getConfig(), "ArkConfig returns a null instance, please check the config file.");
 		Gdx.input.setInputProcessor(this);
 		Gdx.graphics.setForegroundFPS(config.display_fps);
+		Logger.info("System", "OpenGL Version " + Gdx.gl.glGetString(GL20.GL_VERSION));
+		Logger.info("System", "OpenGL Vendor " + Gdx.gl.glGetString(GL20.GL_VENDOR));
 
 		// 2.Character setup
 		Logger.info("App", "Using model asset \"" + config.character_asset + "\"");

--- a/core/src/cn/harryh/arkpets/ArkPets.java
+++ b/core/src/cn/harryh/arkpets/ArkPets.java
@@ -145,7 +145,7 @@ public class ArkPets extends ApplicationAdapter implements InputProcessor {
 		setWindowPos();
 		if (!windowAlpha.isEnded()) {
 			windowAlpha.addProgress(Gdx.graphics.getDeltaTime());
-			hWndMine.setWindowAlpha(windowAlpha.now());
+			cha.alpha = windowAlpha.now();
 		}
 		promiseToolwindowStyle(1);
 

--- a/core/src/cn/harryh/arkpets/Const.java
+++ b/core/src/cn/harryh/arkpets/Const.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
+import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
+
 
 /** Constants definition class.
  */
@@ -92,9 +94,9 @@ public final class Const {
         public static final String urlLicense       = "https://github.com/isHarryh/Ark-Pets";
         public static final String urlModelsZip     = "isHarryh/Ark-Models/archive/refs/heads/main.zip";
         public static final String urlModelsData    = "isHarryh/Ark-Models/main/models_data.json";
-        public static final String tempDirPath      = "temp/";
+        public static final String tempDirPath      = getWorkingDirectory() + "temp/";
         public static final String fileModelsZipName            = "ArkModels";
-        public static final String fileModelsDataPath           = "models_data.json";
+        public static final String fileModelsDataPath           = getWorkingDirectory() + "models_data.json";
         public static final String tempModelsUnzipDirPath       = tempDirPath + "models_unzipped/";
         public static final String tempModelsZipCachePath       = tempDirPath + fileModelsZipName + ".zip";
         public static final String tempQueryVersionCachePath    = tempDirPath + "ApiQueryVersionCache";
@@ -107,8 +109,8 @@ public final class Const {
         public static final int logCoreMaxKeep      = 32;
         public static final int logDesktopMaxKeep   = 8;
 
-        public static final String logCorePath      = "logs/core";
-        public static final String logDesktopPath   = "logs/desktop";
+        public static final String logCorePath      = getWorkingDirectory() + "logs/core";
+        public static final String logDesktopPath   = getWorkingDirectory() + "logs/desktop";
 
         public static final String error    = "ERROR";
         public static final String warn     = "WARN";

--- a/core/src/cn/harryh/arkpets/assets/ModelsDataset.java
+++ b/core/src/cn/harryh/arkpets/assets/ModelsDataset.java
@@ -13,6 +13,8 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Objects;
 
+import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
+
 
 public class ModelsDataset {
     public final HashMap<String, File> storageDirectory;
@@ -48,7 +50,7 @@ public class ModelsDataset {
             // Make up for `assetDir` field
             if (assetItem == null || !storageDirectory.containsKey(assetItem.type))
                 throw new DatasetKeyException("type");
-            assetItem.assetDir = Path.of(storageDirectory.get(assetItem.type).toString(), key).toFile();
+            assetItem.assetDir = Path.of(getWorkingDirectory(), storageDirectory.get(assetItem.type).toString(), key).toFile();
             // Compatible to lower version dataset
             if (assetItem.assetList == null && assetItem.assetId != null && assetItem.checksum != null) {
                 HashMap<String, Object> defaultFileMap = new HashMap<>();

--- a/core/src/cn/harryh/arkpets/concurrent/ProcessPool.java
+++ b/core/src/cn/harryh/arkpets/concurrent/ProcessPool.java
@@ -6,6 +6,7 @@ package cn.harryh.arkpets.concurrent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.*;
 
 
@@ -67,6 +68,8 @@ public final class ProcessPool implements Executor {
                 command.addAll(args);
             // Process execution
             ProcessBuilder builder = new ProcessBuilder(command);
+            Map<String, String> env = builder.environment();
+            env.remove("GDK_BACKEND");
             Process process = builder.inheritIO().start();
             int exitValue = process.waitFor();
             return new ProcessResult(exitValue, process.pid());

--- a/core/src/cn/harryh/arkpets/platform/KWinHWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/KWinHWndCtrl.java
@@ -23,7 +23,7 @@ public class KWinHWndCtrl extends HWndCtrl {
     private static ArkPetsInterface dBusInterface;
 
     protected KWinHWndCtrl(DetailsStruct details) {
-        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(), details.x + details.w.intValue(), details.x));
+        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(), details.x, details.x + details.w.intValue()));
         this.hWnd = details.id;
         this.details = details;
     }
@@ -64,12 +64,12 @@ public class KWinHWndCtrl extends HWndCtrl {
     }
 
     @Override
-    public void setWindowTransparent(boolean enable) {
+    public void setTransparent(boolean enable) {
 
     }
 
     @Override
-    public void setToolWindow(boolean enable) {
+    public void setTaskbar(boolean enable) {
 
     }
 

--- a/core/src/cn/harryh/arkpets/platform/KWinHWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/KWinHWndCtrl.java
@@ -1,0 +1,200 @@
+package cn.harryh.arkpets.platform;
+
+import cn.harryh.arkpets.utils.Logger;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+public class KWinHWndCtrl extends HWndCtrl {
+    protected final String hWnd;
+    protected DetailsStruct details;
+    private static DBusConnection dBusConnection;
+    private static ArkPetsInterface dBusInterface;
+
+    protected KWinHWndCtrl(DetailsStruct details) {
+        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(), details.x + details.w.intValue(), details.x));
+        this.hWnd = details.id;
+        this.details = details;
+    }
+
+    @Override
+    public boolean isForeground() {
+        return dBusInterface.IsActive(hWnd);
+    }
+
+    @Override
+    public boolean isVisible() {
+        return details.visible;
+    }
+
+    @Override
+    public boolean close(int timeout) {
+        return false;
+    }
+
+    @Override
+    public HWndCtrl updated() {
+        return new KWinHWndCtrl(dBusInterface.Details(hWnd));
+    }
+
+    @Override
+    public void setForeground() {
+        dBusInterface.Activate(hWnd);
+    }
+
+    @Override
+    public void setWindowAlpha(float alpha) {
+        dBusInterface.Alpha(hWnd, alpha);
+    }
+
+    @Override
+    public void setWindowPosition(HWndCtrl insertAfter, int x, int y, int w, int h) {
+        dBusInterface.MoveResize(hWnd,x,y,new UInt32(w),new UInt32(h));
+    }
+
+    @Override
+    public void setWindowTransparent(boolean enable) {
+
+    }
+
+    @Override
+    public void setToolWindow(boolean enable) {
+
+    }
+
+    @Override
+    public void setLayered(boolean enable) {
+
+    }
+
+    @Override
+    public void setTopmost(boolean enable) {
+        if (enable) {
+            dBusInterface.Above(hWnd);
+        } else {
+            dBusInterface.Unabove(hWnd);
+        }
+    }
+
+    @Override
+    public void sendMouseEvent(MouseEvent msg, int x, int y) {
+
+    }
+
+    protected static void init() {
+        try {
+            dBusConnection = DBusConnectionBuilder.forSessionBus().build();
+            Logger.info("System", "Connected to DBus");
+            dBusInterface = dBusConnection.getRemoteObject("org.kde.KWin", "/ArkPets", ArkPetsInterface.class);
+            Logger.info("System", "KDE Integration plugin version " + dBusInterface.Version());
+        } catch (DBusException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static void free() {
+        try {
+            dBusConnection.close();
+            Logger.info("System", "Disconnected from DBus");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static KWinHWndCtrl find(String className, String windowName) {
+        return dBusInterface.List().stream().map(KWinHWndCtrl::new).filter((i) -> {
+            if (className == null) {
+                return i.windowText != null && i.windowText.equals(windowName);
+            } else {
+                return i.details.wclass.equals(className) && i.windowText.equals(windowName);
+            }
+        }).findAny().orElse(null);
+    }
+
+    protected static List<KWinHWndCtrl> getWindowList(boolean onlyVisible) {
+        List<KWinHWndCtrl> list = new ArrayList<>(dBusInterface.List().stream().map(KWinHWndCtrl::new).filter(w -> !onlyVisible || w.isVisible()).toList());
+        Collections.reverse(list);
+        return list;
+    }
+
+    protected static KWinHWndCtrl getTopmostWindow() {
+        List<DetailsStruct> list = dBusInterface.List();
+        return new KWinHWndCtrl(list.get(list.size() - 1));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        KWinHWndCtrl hWndCtrl = (KWinHWndCtrl)o;
+        return hWnd.equals(hWndCtrl.hWnd);
+    }
+
+    @Override
+    public int hashCode() {
+        return hWnd.hashCode();
+    }
+
+    @DBusInterfaceName("org.kde.KWin.ArkPets")
+    private interface ArkPetsInterface extends DBusInterface {
+        void MoveResize(String uuid, int x, int y, UInt32 width, UInt32 height);
+
+        void Activate(String uuid);
+
+        void Above(String uuid);
+
+        void Unabove(String uuid);
+
+        List<DetailsStruct> List();
+
+        DetailsStruct Details(String winid);
+
+        void Alpha(String uuid, double alpha);
+
+        boolean IsActive(String uuid);
+
+        UInt32 Version();
+    }
+
+    public static class DetailsStruct extends Struct {
+        @Position(0)
+        public final int x;
+        @Position(1)
+        public final int y;
+        @Position(2)
+        public final UInt32 w;
+        @Position(3)
+        public final UInt32 h;
+        @Position(4)
+        public final String title;
+        @Position(5)
+        public final String wclass;
+        @Position(6)
+        public final boolean visible;
+        @Position(7)
+        public final String id;
+
+        public DetailsStruct(int x, int y, UInt32 w, UInt32 h, String title, String wClass, boolean visible, String id) {
+            this.x = x;
+            this.y = y;
+            this.w = w;
+            this.h = h;
+            this.title = title;
+            this.wclass = wClass;
+            this.visible = visible;
+            this.id = id;
+        }
+    }
+}

--- a/core/src/cn/harryh/arkpets/platform/MutterHWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/MutterHWndCtrl.java
@@ -23,7 +23,7 @@ public class MutterHWndCtrl extends HWndCtrl {
     private static ArkPetsInterface dBusInterface;
 
     protected MutterHWndCtrl(DetailsStruct details) {
-        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(), details.x + details.w.intValue(), details.x));
+        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(),  details.x, details.x + details.w.intValue()));
         this.hWnd = details.id;
         this.details = details;
     }
@@ -60,16 +60,16 @@ public class MutterHWndCtrl extends HWndCtrl {
 
     @Override
     public void setWindowPosition(HWndCtrl insertAfter, int x, int y, int w, int h) {
-        dBusInterface.MoveResize(hWnd,x,y,new UInt32(w),new UInt32(h));
+        dBusInterface.MoveResize(hWnd, x, y, new UInt32(w), new UInt32(h));
     }
 
     @Override
-    public void setWindowTransparent(boolean enable) {
+    public void setTransparent(boolean enable) {
 
     }
 
     @Override
-    public void setToolWindow(boolean enable) {
+    public void setTaskbar(boolean enable) {
 
     }
 

--- a/core/src/cn/harryh/arkpets/platform/MutterHWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/MutterHWndCtrl.java
@@ -1,0 +1,200 @@
+package cn.harryh.arkpets.platform;
+
+import cn.harryh.arkpets.utils.Logger;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+public class MutterHWndCtrl extends HWndCtrl {
+    protected final UInt32 hWnd;
+    protected DetailsStruct details;
+    private static DBusConnection dBusConnection;
+    private static ArkPetsInterface dBusInterface;
+
+    protected MutterHWndCtrl(DetailsStruct details) {
+        super(details.title, new WindowRect(details.y, details.y + details.h.intValue(), details.x + details.w.intValue(), details.x));
+        this.hWnd = details.id;
+        this.details = details;
+    }
+
+    @Override
+    public boolean isForeground() {
+        return dBusInterface.IsActive(hWnd);
+    }
+
+    @Override
+    public boolean isVisible() {
+        return details.visible;
+    }
+
+    @Override
+    public boolean close(int timeout) {
+        return false;
+    }
+
+    @Override
+    public HWndCtrl updated() {
+        return new MutterHWndCtrl(dBusInterface.Details(hWnd));
+    }
+
+    @Override
+    public void setForeground() {
+        dBusInterface.Activate(hWnd);
+    }
+
+    @Override
+    public void setWindowAlpha(float alpha) {
+        dBusInterface.Alpha(hWnd, new UInt32((long) (alpha * 255L)));
+    }
+
+    @Override
+    public void setWindowPosition(HWndCtrl insertAfter, int x, int y, int w, int h) {
+        dBusInterface.MoveResize(hWnd,x,y,new UInt32(w),new UInt32(h));
+    }
+
+    @Override
+    public void setWindowTransparent(boolean enable) {
+
+    }
+
+    @Override
+    public void setToolWindow(boolean enable) {
+
+    }
+
+    @Override
+    public void setLayered(boolean enable) {
+
+    }
+
+    @Override
+    public void setTopmost(boolean enable) {
+        if (enable) {
+            dBusInterface.Above(hWnd);
+        } else {
+            dBusInterface.Unabove(hWnd);
+        }
+    }
+
+    @Override
+    public void sendMouseEvent(MouseEvent msg, int x, int y) {
+
+    }
+
+    protected static void init() {
+        try {
+            dBusConnection = DBusConnectionBuilder.forSessionBus().build();
+            Logger.info("System", "Connected to DBus");
+            dBusInterface = dBusConnection.getRemoteObject("org.gnome.Shell", "/org/gnome/Shell/Extensions/ArkPets", ArkPetsInterface.class);
+            Logger.info("System", "GNOME Integration extension version " + dBusInterface.Version());
+        } catch (DBusException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static void free() {
+        try {
+            dBusConnection.close();
+            Logger.info("System", "Disconnected from DBus");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static MutterHWndCtrl find(String className, String windowName) {
+        return dBusInterface.List().stream().map(MutterHWndCtrl::new).filter((i) -> {
+            if (className == null) {
+                return i.windowText != null && i.windowText.equals(windowName);
+            } else {
+                return i.details.wclass.equals(className) && i.windowText.equals(windowName);
+            }
+        }).findAny().orElse(null);
+    }
+
+    protected static List<MutterHWndCtrl> getWindowList(boolean onlyVisible) {
+        List<MutterHWndCtrl> list = new ArrayList<>(dBusInterface.List().stream().map(MutterHWndCtrl::new).filter(w -> !onlyVisible || w.isVisible()).toList());
+        Collections.reverse(list);
+        return list;
+    }
+
+    protected static MutterHWndCtrl getTopmostWindow() {
+        List<DetailsStruct> list = dBusInterface.List();
+        return new MutterHWndCtrl(list.get(list.size() - 1));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MutterHWndCtrl hWndCtrl = (MutterHWndCtrl)o;
+        return hWnd.equals(hWndCtrl.hWnd);
+    }
+
+    @Override
+    public int hashCode() {
+        return hWnd.hashCode();
+    }
+
+    @DBusInterfaceName("org.gnome.Shell.Extensions.ArkPets")
+    private interface ArkPetsInterface extends DBusInterface {
+        void MoveResize(UInt32 winid, int x, int y, UInt32 width, UInt32 height);
+
+        void Activate(UInt32 winid);
+
+        void Above(UInt32 winid);
+
+        void Unabove(UInt32 winid);
+
+        List<DetailsStruct> List();
+
+        DetailsStruct Details(UInt32 winid);
+
+        void Alpha(UInt32 winid, UInt32 alpha);
+
+        boolean IsActive(UInt32 winid);
+
+        UInt32 Version();
+    }
+
+    public static class DetailsStruct extends Struct {
+        @Position(0)
+        public final int x;
+        @Position(1)
+        public final int y;
+        @Position(2)
+        public final UInt32 w;
+        @Position(3)
+        public final UInt32 h;
+        @Position(4)
+        public final String title;
+        @Position(5)
+        public final String wclass;
+        @Position(6)
+        public final boolean visible;
+        @Position(7)
+        public final UInt32 id;
+
+        public DetailsStruct(int x, int y, UInt32 w, UInt32 h, String title, String wClass, boolean visible, UInt32 id) {
+            this.x = x;
+            this.y = y;
+            this.w = w;
+            this.h = h;
+            this.title = title;
+            this.wclass = wClass;
+            this.visible = visible;
+            this.id = id;
+        }
+    }
+}

--- a/core/src/cn/harryh/arkpets/platform/NullHWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/NullHWndCtrl.java
@@ -4,9 +4,25 @@
 package cn.harryh.arkpets.platform;
 
 
+import com.badlogic.gdx.Gdx;
+
+
 public class NullHWndCtrl extends HWndCtrl {
+    private static boolean startupFind;
+    private int lastw, lasth;
+
     public NullHWndCtrl() {
         super("", new WindowRect());
+    }
+
+    public static NullHWndCtrl find(String className, String windowName){
+        if(windowName.equals("ArkPets")){
+            if(!NullHWndCtrl.startupFind){
+                NullHWndCtrl.startupFind=true;
+                return null;
+            }
+        }
+        return new NullHWndCtrl();
     }
 
     @Override
@@ -39,6 +55,11 @@ public class NullHWndCtrl extends HWndCtrl {
 
     @Override
     public void setWindowPosition(HWndCtrl insertAfter, int x, int y, int w, int h) {
+        if(lasth!=h||lastw!=w){
+            lasth=h;
+            lastw=w;
+            Gdx.graphics.setWindowedMode(w,h);
+        }
     }
 
     @Override

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -72,7 +72,7 @@ public enum WindowSystem {
                 return User32HWndCtrl.find(className, windowText);
             }
             default -> {
-                return new NullHWndCtrl();
+                return NullHWndCtrl.find(className, windowText);
             }
         }
     }

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -53,6 +53,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 MutterHWndCtrl.init();
             }
+            case KWIN -> {
+                KWinHWndCtrl.init();
+            }
             case X11 -> {
                 X11HWndCtrl.init();
             }
@@ -79,6 +82,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.find(className, windowText);
             }
+            case KWIN -> {
+                return KWinHWndCtrl.find(className, windowText);
+            }
             case X11 -> {
                 return X11HWndCtrl.find(className, windowText);
             }
@@ -100,6 +106,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.getWindowList(onlyVisible);
             }
+            case KWIN -> {
+                return KWinHWndCtrl.getWindowList(onlyVisible);
+            }
             case X11 -> {
                 return X11HWndCtrl.getWindowList(onlyVisible);
             }
@@ -120,6 +129,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.getTopmostWindow();
             }
+            case KWIN -> {
+                return KWinHWndCtrl.getTopmostWindow();
+            }
             case X11 -> {
                 return X11HWndCtrl.getTopmost();
             }
@@ -135,6 +147,9 @@ public enum WindowSystem {
         switch (PLATFORM) {
             case MUTTER -> {
                 MutterHWndCtrl.free();
+            }
+            case KWIN -> {
+                KWinHWndCtrl.free();
             }
             case X11 -> {
                 X11HWndCtrl.free();

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -41,10 +41,24 @@ public enum WindowSystem {
     }
 
     /** Initializes the platform window system.
+     * @param platform WindowSystem to initialize.
      */
-    public static void init() {
-        PLATFORM = detectWindowSystem();
+    public static void init(WindowSystem platform) {
+        PLATFORM = platform;
+        if (PLATFORM == WindowSystem.AUTO){
+            PLATFORM = detectWindowSystem();
+        }
         Logger.info("System", "Using " + PLATFORM.toString() + " Window System");
+        switch (PLATFORM) {
+            // TODO
+        }
+    }
+
+    /** Get current WindowSystem.
+     * @return The current WindowSystem.
+     */
+    public static WindowSystem getWindowSystem() {
+        return PLATFORM;
     }
 
     /** Finds a window.

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -53,6 +53,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 MutterHWndCtrl.init();
             }
+            case X11 -> {
+                X11HWndCtrl.init();
+            }
         }
     }
 
@@ -76,6 +79,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.find(className, windowText);
             }
+            case X11 -> {
+                return X11HWndCtrl.find(className, windowText);
+            }
             default -> {
                 return NullHWndCtrl.find(className, windowText);
             }
@@ -94,6 +100,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.getWindowList(onlyVisible);
             }
+            case X11 -> {
+                return X11HWndCtrl.getWindowList(onlyVisible);
+            }
             default -> {
                 return new ArrayList<>();
             }
@@ -111,6 +120,9 @@ public enum WindowSystem {
             case MUTTER -> {
                 return MutterHWndCtrl.getTopmostWindow();
             }
+            case X11 -> {
+                return X11HWndCtrl.getTopmost();
+            }
             default -> {
                 return new NullHWndCtrl();
             }
@@ -123,6 +135,9 @@ public enum WindowSystem {
         switch (PLATFORM) {
             case MUTTER -> {
                 MutterHWndCtrl.free();
+            }
+            case X11 -> {
+                X11HWndCtrl.free();
             }
         }
     }

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -111,4 +111,17 @@ public enum WindowSystem {
     public static void free() {
         // TODO
     }
+
+    /** Return current WindowSystem should enable resize.
+     */
+    public static boolean needResize() {
+        switch (PLATFORM) {
+            case X11, MUTTER, KWIN -> {
+                return true;
+            }
+            default -> {
+                return false;
+            }
+        }
+    }
 }

--- a/core/src/cn/harryh/arkpets/platform/WindowSystem.java
+++ b/core/src/cn/harryh/arkpets/platform/WindowSystem.java
@@ -50,7 +50,9 @@ public enum WindowSystem {
         }
         Logger.info("System", "Using " + PLATFORM.toString() + " Window System");
         switch (PLATFORM) {
-            // TODO
+            case MUTTER -> {
+                MutterHWndCtrl.init();
+            }
         }
     }
 
@@ -71,6 +73,9 @@ public enum WindowSystem {
             case USER32 -> {
                 return User32HWndCtrl.find(className, windowText);
             }
+            case MUTTER -> {
+                return MutterHWndCtrl.find(className, windowText);
+            }
             default -> {
                 return NullHWndCtrl.find(className, windowText);
             }
@@ -86,6 +91,9 @@ public enum WindowSystem {
             case USER32 -> {
                 return User32HWndCtrl.getWindowList(onlyVisible);
             }
+            case MUTTER -> {
+                return MutterHWndCtrl.getWindowList(onlyVisible);
+            }
             default -> {
                 return new ArrayList<>();
             }
@@ -100,6 +108,9 @@ public enum WindowSystem {
             case USER32 -> {
                 return User32HWndCtrl.getTopmostWindow();
             }
+            case MUTTER -> {
+                return MutterHWndCtrl.getTopmostWindow();
+            }
             default -> {
                 return new NullHWndCtrl();
             }
@@ -109,7 +120,11 @@ public enum WindowSystem {
     /** Frees all the resources.
      */
     public static void free() {
-        // TODO
+        switch (PLATFORM) {
+            case MUTTER -> {
+                MutterHWndCtrl.free();
+            }
+        }
     }
 
     /** Return current WindowSystem should enable resize.

--- a/core/src/cn/harryh/arkpets/platform/X11HWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/X11HWndCtrl.java
@@ -104,7 +104,7 @@ public class X11HWndCtrl extends HWndCtrl {
         int finy = yVal - netFrame[2] + gtkFrame[2];
         int finh = height.getValue() + addHeight - removeHeight;
         int finw = width.getValue() + addWidth - removeWidth;
-        return new WindowRect(finy, finy + finh, finx + finw, finx);
+        return new WindowRect(finy, finy + finh, finx, finx + finw);
     }
 
     @Override
@@ -158,13 +158,13 @@ public class X11HWndCtrl extends HWndCtrl {
     }
 
     @Override
-    public void setWindowTransparent(boolean transparent) {
+    public void setTransparent(boolean transparent) {
         // unnecessary in X11.
     }
 
     @Override
-    public void setToolWindow(boolean enable) {
-        if (enable) {
+    public void setTaskbar(boolean enable) {
+        if (!enable) {
             clientMsg(hWnd, "_NET_WM_STATE", STATE_ADD, getAtom("_NET_WM_STATE_SKIP_TASKBAR").intValue(), 0, 0, 0);
         } else {
             clientMsg(hWnd, "_NET_WM_STATE", STATE_REMOVE, getAtom("_NET_WM_STATE_SKIP_TASKBAR").intValue(), 0, 0, 0);

--- a/core/src/cn/harryh/arkpets/platform/X11HWndCtrl.java
+++ b/core/src/cn/harryh/arkpets/platform/X11HWndCtrl.java
@@ -1,0 +1,473 @@
+package cn.harryh.arkpets.platform;
+
+import cn.harryh.arkpets.utils.Logger;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.unix.X11;
+import com.sun.jna.ptr.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+
+public class X11HWndCtrl extends HWndCtrl {
+    private static final HashMap<String, X11Ext.Atom> atomsHash = new HashMap<>();
+    private static X11.Display display;
+    private static final X11Ext x11 = X11Ext.INSTANCE;
+    protected final X11.Window hWnd;
+
+    public static final int MAX_PROPERTY_VALUE_LEN = 4096;
+    public static final int STATE_REMOVE = 0;
+    public static final int STATE_ADD = 1;
+
+    public X11HWndCtrl(X11Ext.Window hWnd) {
+        super(winText(hWnd),getWindowRect(hWnd));
+        this.hWnd=hWnd;
+    }
+
+    public static void init() {
+        display = x11.XOpenDisplay(null);
+
+        if (display == null) {
+            throw new RuntimeException("Cannot open X display");
+        } else {
+            Logger.info("System", "Connected to X display");
+        }
+    }
+
+    public static HWndCtrl find(String className, String windowName) {
+        X11Ext.Window[] wids = getWindows();
+        for (X11Ext.Window win : wids) {
+            String wtitle = winText(win);
+            String wclass = getUtf8Property(win, X11.XA_STRING, X11.XA_WM_CLASS);
+            if (className == null) {
+                if (wtitle.equals(windowName)) {
+                    return new X11HWndCtrl(win);
+                }
+            } else {
+                if (wclass.equals(className) && wtitle.equals(windowName)) {
+                    return new X11HWndCtrl(win);
+                }
+            }
+        }
+        return null;
+    }
+
+    public static List<X11HWndCtrl> getWindowList(boolean onlyVisible) {
+        ArrayList<X11HWndCtrl> windowList = new ArrayList<>();
+        X11.Window[] wins = getWindows();
+        for (X11.Window win : wins) {
+            if (!onlyVisible || visible(win)) {
+                windowList.add(new X11HWndCtrl(win));
+            }
+        }
+        Collections.reverse(windowList);
+        return windowList;
+    }
+
+    public static HWndCtrl getTopmost() {
+        List<X11HWndCtrl> list = getWindowList(true);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    public static void free() {
+        x11.XCloseDisplay(display);
+        Logger.info("System", "Disconnected from X display");
+    }
+
+    protected static WindowRect getWindowRect(X11Ext.Window hWnd) {
+        X11.WindowByReference junkRoot = new X11.WindowByReference();
+        IntByReference junkX = new IntByReference();
+        IntByReference junkY = new IntByReference();
+        IntByReference x = new IntByReference();
+        IntByReference y = new IntByReference();
+        IntByReference width = new IntByReference();
+        IntByReference height = new IntByReference();
+        IntByReference border_width = new IntByReference();
+        IntByReference depth = new IntByReference();
+
+        x11.XGetGeometry(display, hWnd, junkRoot, junkX, junkY, width, height, border_width, depth);
+
+        x11.XTranslateCoordinates(display, hWnd, junkRoot.getValue(), 0, 0, x, y, junkRoot);
+
+        int xVal = x.getValue();
+        int yVal = y.getValue();
+        int[] netFrame = getWMFrameBorder(hWnd, false);
+        int addHeight = netFrame[2] + netFrame[3];
+        int addWidth = netFrame[0] + netFrame[1];
+        int[] gtkFrame = getWMFrameBorder(hWnd, true);
+        int removeHeight = gtkFrame[2] + gtkFrame[3];
+        int removeWidth = gtkFrame[0] + gtkFrame[1];
+
+        int finx = xVal - netFrame[0] + gtkFrame[0];
+        int finy = yVal - netFrame[2] + gtkFrame[2];
+        int finh = height.getValue() + addHeight - removeHeight;
+        int finw = width.getValue() + addWidth - removeWidth;
+        return new WindowRect(finy, finy + finh, finx + finw, finx);
+    }
+
+    @Override
+    public boolean isForeground() {
+        X11Ext.Window rootWindow = x11.XDefaultRootWindow(display);
+        long win = getIntProperty(rootWindow, X11Ext.XA_WINDOW, getAtom("_NET_ACTIVE_WINDOW"));
+        return hWnd.longValue() == win;
+    }
+
+    @Override
+    public boolean isVisible() {
+        return visible(hWnd);
+    }
+
+    @Override
+    public boolean close(int timeout) {
+        //todo timeout
+        clientMsg(hWnd, "_NET_CLOSE_WINDOW", 0, 0, 0, 0, 0);
+        return true;
+    }
+
+    @Override
+    public HWndCtrl updated() {
+        return new X11HWndCtrl(hWnd);
+    }
+
+    @Override
+    public void setForeground() {
+        clientMsg(hWnd, "_NET_ACTIVE_WINDOW", 0, 0, 0, 0, 0);
+        x11.XMapRaised(display, hWnd);
+    }
+
+    @Override
+    public void setWindowAlpha(float alpha) {
+        //Pointer mem=new Memory(Native.getNativeSize());
+        if (alpha == 1.0) {
+            x11.XDeleteProperty(display, hWnd, getAtom("_NET_WM_WINDOW_OPACITY"));
+            return;
+        }
+        LongByReference opacity = new LongByReference((long) (0xffffffffL * alpha));
+        x11.XChangeProperty(display, hWnd, getAtom("_NET_WM_WINDOW_OPACITY"), X11.XA_CARDINAL, 32, X11.PropModeReplace, opacity.getPointer(), 1);
+    }
+
+    @Override
+    public void setWindowPosition(HWndCtrl insertAfter, int x, int y, int w, int h) {
+        //todo insert
+
+        // 0000 0000 1111 0001
+        //clientMsg(hWnd,"_NET_MOVERESIZE_WINDOW",3840,x,y,w,h);
+        x11.XMoveResizeWindow(display, hWnd, x, y, w, h);
+    }
+
+    @Override
+    public void setWindowTransparent(boolean transparent) {
+        // unnecessary in X11.
+    }
+
+    @Override
+    public void setToolWindow(boolean enable) {
+        if (enable) {
+            clientMsg(hWnd, "_NET_WM_STATE", STATE_ADD, getAtom("_NET_WM_STATE_SKIP_TASKBAR").intValue(), 0, 0, 0);
+        } else {
+            clientMsg(hWnd, "_NET_WM_STATE", STATE_REMOVE, getAtom("_NET_WM_STATE_SKIP_TASKBAR").intValue(), 0, 0, 0);
+        }
+    }
+
+    @Override
+    public void setLayered(boolean enable) {
+        // unnecessary in X11.
+    }
+
+    @Override
+    public void setTopmost(boolean enable) {
+        if (enable) {
+            clientMsg(hWnd, "_NET_WM_STATE", STATE_ADD, getAtom("_NET_WM_STATE_ABOVE").intValue(), 0, 0, 0);
+        } else {
+            clientMsg(hWnd, "_NET_WM_STATE", STATE_REMOVE, getAtom("_NET_WM_STATE_ABOVE").intValue(), 0, 0, 0);
+        }
+    }
+
+    @Override
+    public void sendMouseEvent(MouseEvent msg, int x, int y) {
+        //todo
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        X11HWndCtrl hWndCtrl = (X11HWndCtrl)o;
+        return hWnd.equals(hWndCtrl.hWnd);
+    }
+
+    @Override
+    public int hashCode() {
+        return hWnd.hashCode();
+    }
+
+    private static int bytesToInt(byte[] prop, int offset) {
+        return ((prop[3 + offset] & 0xff) << 24)
+                | ((prop[2 + offset] & 0xff) << 16)
+                | ((prop[1 + offset] & 0xff) << 8)
+                | ((prop[offset] & 0xff));
+    }
+
+    private static X11.Atom getAtom(String name) {
+        X11.Atom atom = atomsHash.get(name);
+        if (atom == null) {
+            atom = x11.XInternAtom(display, name, false);
+            atomsHash.put(name, atom);
+        }
+        return atom;
+    }
+
+    private static byte[] getProperty(X11.Window win, X11.Atom xa_prop_type, X11.Atom xa_prop_name) {
+        X11.AtomByReference xa_ret_type_ref = new X11.AtomByReference();
+        IntByReference ret_format_ref = new IntByReference();
+        NativeLongByReference ret_nitems_ref = new NativeLongByReference();
+        NativeLongByReference ret_bytes_after_ref = new NativeLongByReference();
+        PointerByReference ret_prop_ref = new PointerByReference();
+
+        NativeLong long_offset = new NativeLong(0);
+        NativeLong long_length = new NativeLong(MAX_PROPERTY_VALUE_LEN / 4);
+
+        /* MAX_PROPERTY_VALUE_LEN / 4 explanation (XGetWindowProperty manpage):
+         *
+         * long_length = Specifies the length in 32-bit multiples of the
+         *               data to be retrieved.
+         */
+        if (x11.XGetWindowProperty(display, win, xa_prop_name, long_offset, long_length, false,
+                xa_prop_type, xa_ret_type_ref, ret_format_ref,
+                ret_nitems_ref, ret_bytes_after_ref, ret_prop_ref) != X11.Success) {
+            String prop_name = x11.XGetAtomName(display, xa_prop_name);
+            throw new RuntimeException("Cannot get " + prop_name + " property.");
+        }
+
+        X11.Atom xa_ret_type = xa_ret_type_ref.getValue();
+        Pointer ret_prop = ret_prop_ref.getValue();
+
+        if (xa_ret_type == null) {
+            //the specified property does not exist for the specified window
+            throw new RuntimeException("Type not found");
+        }
+
+        if (xa_prop_type == null ||
+                !xa_ret_type.toNative().equals(xa_prop_type.toNative())) {
+            x11.XFree(ret_prop);
+            String prop_name = x11.XGetAtomName(display, xa_prop_name);
+            throw new RuntimeException("Invalid type of " + prop_name + " property");
+        }
+
+        int ret_format = ret_format_ref.getValue();
+        long ret_nitems = ret_nitems_ref.getValue().longValue();
+
+        // null terminate the result to make string handling easier
+        int nbytes;
+        if (ret_format == 32)
+            nbytes = Native.LONG_SIZE;
+        else if (ret_format == 16)
+            nbytes = Native.LONG_SIZE / 2;
+        else if (ret_format == 8)
+            nbytes = 1;
+        else if (ret_format == 0)
+            nbytes = 0;
+        else
+            throw new RuntimeException("Invalid return format");
+        int length = Math.min((int) ret_nitems * nbytes, MAX_PROPERTY_VALUE_LEN);
+
+        byte[] ret = ret_prop.getByteArray(0, length);
+
+        x11.XFree(ret_prop);
+        return ret;
+    }
+
+    private static X11Ext.Window[] getWindows() {
+        X11Ext.Window rootWindow = x11.XDefaultRootWindow(display);
+        byte[] bytes = getProperty(rootWindow, X11Ext.XA_WINDOW, getAtom("_NET_CLIENT_LIST_STACKING"));
+
+        X11Ext.Window[] windowList = new X11Ext.Window[bytes.length / X11.Window.SIZE];
+
+        for (int i = 0; i < windowList.length; i++) {
+            windowList[i] = new X11.Window(bytesToInt(bytes, X11.XID.SIZE * i));
+        }
+
+        return windowList;
+    }
+
+    private static String getUtf8Property(X11.Window win, X11.Atom xa_prop_type, X11.Atom xa_prop_name) {
+        byte[] property = getNullReplacedStringProperty(win, xa_prop_type, xa_prop_name);
+        if (property == null) {
+            return "";
+        }
+        return new String(property, StandardCharsets.UTF_8);
+    }
+
+    public static byte[] getNullReplacedStringProperty(X11.Window win, X11.Atom xa_prop_type, X11.Atom xa_prop_name) {
+        byte[] bytes = getProperty(win, xa_prop_type, xa_prop_name);
+
+        if (bytes == null) {
+            return null;
+        }
+
+        // search for '\0'
+        int i;
+        for (i = 0; i < bytes.length; i++) {
+            if (bytes[i] == '\0') {
+                bytes[i] = '.';
+            }
+        }
+
+        return bytes;
+    }
+
+    private static String winText(X11Ext.Window hWnd) {
+        String title;
+        title = getUtf8Property(hWnd, getAtom("UTF8_STRING"), getAtom("_NET_WM_NAME"));
+        return title;
+    }
+
+    private static int[] getWMFrameBorder(X11.Window hWnd, boolean gtkFrame) {
+        X11.Atom xa_prop_type = getAtom("CARDINAL");
+        X11.Atom xa_prop_name;
+        if (gtkFrame) {
+            xa_prop_name = getAtom("_GTK_FRAME_EXTENTS");
+        } else {
+            xa_prop_name = getAtom("_NET_FRAME_EXTENTS");
+        }
+        X11.AtomByReference xa_ret_type_ref = new X11.AtomByReference();
+        IntByReference ret_format_ref = new IntByReference();
+        NativeLongByReference ret_nitems_ref = new NativeLongByReference();
+        NativeLongByReference ret_bytes_after_ref = new NativeLongByReference();
+        PointerByReference ret_prop_ref = new PointerByReference();
+
+        NativeLong long_offset = new NativeLong(0);
+        NativeLong long_length = new NativeLong(MAX_PROPERTY_VALUE_LEN / 4);
+
+        /* MAX_PROPERTY_VALUE_LEN / 4 explanation (XGetWindowProperty manpage):
+         *
+         * long_length = Specifies the length in 32-bit multiples of the
+         *               data to be retrieved.
+         */
+        if (x11.XGetWindowProperty(display, hWnd, xa_prop_name, long_offset, long_length, false,
+                xa_prop_type, xa_ret_type_ref, ret_format_ref,
+                ret_nitems_ref, ret_bytes_after_ref, ret_prop_ref) != X11.Success) {
+            return new int[]{0, 0, 0, 0};
+        }
+
+        X11.Atom xa_ret_type = xa_ret_type_ref.getValue();
+        Pointer ret_prop = ret_prop_ref.getValue();
+
+        if (xa_ret_type == null) {
+            return new int[]{0, 0, 0, 0};
+        }
+
+        if (xa_prop_type == null ||
+                !xa_ret_type.toNative().equals(xa_prop_type.toNative())) {
+            x11.XFree(ret_prop);
+            return new int[]{0, 0, 0, 0};
+        }
+
+        int ret_nitems = ret_nitems_ref.getValue().intValue();
+
+        long[] ret = ret_prop.getLongArray(0, ret_nitems);
+        int[] intArray = Arrays.stream(ret).mapToInt(i -> (int) i).toArray();
+        x11.XFree(ret_prop);
+        return intArray;
+    }
+
+    private static Integer getIntProperty(X11.Window hWnd, X11.Atom xa_prop_type, X11.Atom xa_prop_name) {
+        byte[] property = getProperty(hWnd, xa_prop_type, xa_prop_name);
+        return bytesToInt(property, 0);
+    }
+
+    private static boolean visible(X11.Window hWnd) {
+        X11.XWindowAttributes attr = new X11.XWindowAttributes();
+        x11.XGetWindowAttributes(display, hWnd, attr);
+        if (attr.map_state != x11.IsViewable) {
+            return false;
+        }
+        X11.Window root = x11.XDefaultRootWindow(display);
+        boolean visible = isWMState(hWnd, getAtom("_NET_WM_STATE_HIDDEN"));
+        int winDesktop = getIntProperty(hWnd, X11.XA_CARDINAL, getAtom("_NET_WM_DESKTOP"));
+        int currentDesktop = getIntProperty(root, X11.XA_CARDINAL, getAtom("_NET_CURRENT_DESKTOP"));
+        boolean inWorkspace = winDesktop == currentDesktop;
+        if (!visible || !inWorkspace) {
+            return false;
+        }
+
+        return attr.y != attr.y + attr.height && attr.x != attr.x + attr.width;
+    }
+
+    private static boolean isWMState(X11.Window hWnd, X11.Atom wm_prop) {
+        X11.Atom xa_prop_type = getAtom("ATOM");
+        X11.Atom xa_prop_name = getAtom("_NET_WM_STATE");
+        X11.AtomByReference xa_ret_type_ref = new X11.AtomByReference();
+        IntByReference ret_format_ref = new IntByReference();
+        NativeLongByReference ret_nitems_ref = new NativeLongByReference();
+        NativeLongByReference ret_bytes_after_ref = new NativeLongByReference();
+        PointerByReference ret_prop_ref = new PointerByReference();
+
+        NativeLong long_offset = new NativeLong(0);
+        NativeLong long_length = new NativeLong(MAX_PROPERTY_VALUE_LEN / 4);
+
+        if (x11.XGetWindowProperty(display, hWnd, xa_prop_name, long_offset, long_length, false,
+                xa_prop_type, xa_ret_type_ref, ret_format_ref,
+                ret_nitems_ref, ret_bytes_after_ref, ret_prop_ref) != X11.Success) {
+            return false;
+        }
+
+        X11.Atom xa_ret_type = xa_ret_type_ref.getValue();
+        Pointer ret_prop = ret_prop_ref.getValue();
+
+        if (xa_ret_type == null) {
+            return false;
+        }
+
+        if (xa_prop_type == null ||
+                !xa_ret_type.toNative().equals(xa_prop_type.toNative())) {
+            x11.XFree(ret_prop);
+            return false;
+        }
+
+        int ret_nitems = ret_nitems_ref.getValue().intValue();
+
+        char[] ret = ret_prop.getCharArray(0, ret_nitems);
+
+        x11.XFree(ret_prop);
+        for (char c : ret) {
+            if (((long) c) == wm_prop.longValue()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void clientMsg(X11.Window hWnd, String msg, int data0, int data1, int data2, int data3, int data4) {
+        X11.XClientMessageEvent event;
+        NativeLong mask = new NativeLong(X11.SubstructureRedirectMask | X11.SubstructureNotifyMask);
+        X11.Window root = x11.XDefaultRootWindow(display);
+        event = new X11.XClientMessageEvent();
+        event.type = X11.ClientMessage;
+        event.serial = new NativeLong(0);
+        event.send_event = 1;
+        event.message_type = getAtom(msg);
+        event.window = hWnd;
+        event.format = 32;
+        event.data.setType(NativeLong[].class);
+        event.data.l[0] = new NativeLong(data0);
+        event.data.l[1] = new NativeLong(data1);
+        event.data.l[2] = new NativeLong(data2);
+        event.data.l[3] = new NativeLong(data3);
+        event.data.l[4] = new NativeLong(data4);
+
+        X11.XEvent e = new X11.XEvent();
+        e.setTypedValue(event);
+
+        x11.XSendEvent(display, root, 0, mask, e);
+    }
+
+    public interface X11Ext extends X11 {
+        X11Ext INSTANCE = Native.load("X11", X11Ext.class);
+
+        void XMoveResizeWindow(Display display, Window w, int x, int y, int width, int height);
+    }
+}

--- a/core/src/cn/harryh/arkpets/tray/HostTray.java
+++ b/core/src/cn/harryh/arkpets/tray/HostTray.java
@@ -75,7 +75,14 @@ public class HostTray {
             trayIcon.setImageAutoSize(true);
 
             trayIcon.addMouseListener(new MouseAdapter() {
+                @Override
                 public void mouseReleased(MouseEvent e) {
+                    if (e.getButton() == 3 && e.isPopupTrigger())
+                        showDialog(e.getX() + 5, e.getY());
+                }
+
+                @Override
+                public void mousePressed(MouseEvent e) {
                     if (e.getButton() == 3 && e.isPopupTrigger())
                         showDialog(e.getX() + 5, e.getY());
                 }

--- a/core/src/cn/harryh/arkpets/tray/MemberTrayImpl.java
+++ b/core/src/cn/harryh/arkpets/tray/MemberTrayImpl.java
@@ -85,6 +85,12 @@ public class MemberTrayImpl extends MemberTray {
                 if (e.getButton() == 3 && e.isPopupTrigger())
                     showDialog(e.getX() + 5, e.getY());
             }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.getButton() == 3 && e.isPopupTrigger())
+                    showDialog(e.getX() + 5, e.getY());
+            }
         });
         return icon;
     }

--- a/core/src/cn/harryh/arkpets/tray/MemberTrayImpl.java
+++ b/core/src/cn/harryh/arkpets/tray/MemberTrayImpl.java
@@ -106,7 +106,7 @@ public class MemberTrayImpl extends MemberTray {
             public void run() {
                 Gdx.app.exit();
             }
-        }, (int)durationNormal.toSeconds());
+        }, (int)durationNormal.toMillis());
     }
 
     @Override

--- a/desktop/src/cn/harryh/arkpets/DesktopLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/DesktopLauncher.java
@@ -6,6 +6,7 @@ package cn.harryh.arkpets;
 import cn.harryh.arkpets.utils.ArgPending;
 import cn.harryh.arkpets.utils.Logger;
 import javafx.application.Application;
+import org.lwjgl.glfw.GLFW;
 
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -57,7 +58,8 @@ public class DesktopLauncher {
                 System.exit(0);
             }
         };
-
+        // Disable libdecor to avoid glfw and javafx problem
+        GLFW.glfwInitHint(GLFW.GLFW_WAYLAND_LIBDECOR, GLFW.GLFW_WAYLAND_DISABLE_LIBDECOR);
         // Java FX bootstrap
         Application.launch(ArkHomeFX.class, args);
         Logger.info("System", "Exited from DesktopLauncher successfully");

--- a/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
@@ -8,7 +8,6 @@ import cn.harryh.arkpets.platform.WindowSystem;
 import cn.harryh.arkpets.utils.Logger;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
-import com.badlogic.gdx.graphics.Color;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.system.MemoryUtil;

--- a/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
@@ -56,15 +56,22 @@ public class EmbeddedLauncher {
         Logger.info("System", "Entering the app of EmbeddedLauncher");
         Logger.info("System", "ArkPets version is " + appVersion);
         Logger.debug("System", "Default charset is " + Charset.defaultCharset());
-
+        ArkConfig appConfig = Objects.requireNonNull(ArkConfig.getConfig(), "ArkConfig returns a null instance, please check the config file.");
+        WindowSystem windowSystem;
         try {
-            WindowSystem.init();
+            windowSystem = WindowSystem.values()[appConfig.window_system];
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Logger.warn("System", "Invalid window system,using auto detect");
+            windowSystem = WindowSystem.AUTO;
+        }
+        try {
+            WindowSystem.init(windowSystem);
             Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
             // Configure FPS
             config.setForegroundFPS(fpsDefault);
             config.setIdleFPS(fpsDefault);
             // Configure window layout
-            config.setDecorated(false);
+            config.setDecorated(WindowSystem.getWindowSystem() == WindowSystem.NULL);
             config.setResizable(false);
             config.setWindowedMode(coreWidthDefault, coreHeightDefault);
             config.setWindowPosition(0, 0);

--- a/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
@@ -26,11 +26,12 @@ public class EmbeddedLauncher {
     // Please note that on macOS your application needs to be started with the -XstartOnFirstThread JVM argument
 
     public static void main (String[] args) {
+        ArkConfig appConfig = Objects.requireNonNull(ArkConfig.getConfig());
         ArgPending.argCache = args;
         // Logger
         Logger.initialize(LogConfig.logCorePath, LogConfig.logCoreMaxKeep);
         try {
-            Logger.setLevel(Objects.requireNonNull(ArkConfig.getConfig()).logging_level);
+            Logger.setLevel(appConfig.logging_level);
         } catch (Exception ignored) {
         }
         new ArgPending(LogConfig.errorArg, args) {
@@ -56,7 +57,6 @@ public class EmbeddedLauncher {
         Logger.info("System", "Entering the app of EmbeddedLauncher");
         Logger.info("System", "ArkPets version is " + appVersion);
         Logger.debug("System", "Default charset is " + Charset.defaultCharset());
-        ArkConfig appConfig = Objects.requireNonNull(ArkConfig.getConfig(), "ArkConfig returns a null instance, please check the config file.");
         WindowSystem windowSystem;
         try {
             windowSystem = WindowSystem.values()[appConfig.window_system];
@@ -81,7 +81,7 @@ public class EmbeddedLauncher {
             // Configure window display
             config.setInitialVisible(true);
             config.setTransparentFramebuffer(true);
-            config.setInitialBackgroundColor(Color.CLEAR);
+            config.setInitialBackgroundColor(appConfig.getBackgroundColor());
             // Handle GLFW error
             GLFW.glfwSetErrorCallback(new GLFWErrorCallback() {
                 @Override

--- a/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
+++ b/desktop/src/cn/harryh/arkpets/EmbeddedLauncher.java
@@ -72,7 +72,7 @@ public class EmbeddedLauncher {
             config.setIdleFPS(fpsDefault);
             // Configure window layout
             config.setDecorated(WindowSystem.getWindowSystem() == WindowSystem.NULL);
-            config.setResizable(false);
+            config.setResizable(WindowSystem.needResize());
             config.setWindowedMode(coreWidthDefault, coreHeightDefault);
             config.setWindowPosition(0, 0);
             // Configure window title

--- a/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
@@ -30,11 +30,11 @@ import javafx.util.Duration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
 import static cn.harryh.arkpets.Const.*;
 import static cn.harryh.arkpets.utils.GuiComponents.Handbook;
 
@@ -146,6 +146,7 @@ public final class RootModule implements Controller<ArkHomeFX> {
             protected Boolean call() throws InterruptedException, ExecutionException {
                 // Update the logging level arg to match the custom value of the Launcher.
                 ArrayList<String> args = new ArrayList<>(Arrays.asList(ArgPending.argCache.clone()));
+                ArrayList<String> jvmArgs = new ArrayList<>();
                 args.remove(LogConfig.errorArg);
                 args.remove(LogConfig.warnArg);
                 args.remove(LogConfig.infoArg);
@@ -158,10 +159,14 @@ public final class RootModule implements Controller<ArkHomeFX> {
                     default -> "";
                 };
                 args.add(temp);
+                // Set working directory.
+                if(System.getProperty("arkpets.workdir") != null){
+                    jvmArgs.add("-Darkpets.workdir="+getWorkingDirectory());
+                }
                 // Start ArkPets core.
                 Logger.info("Launcher", "Launching " + app.config.character_asset);
                 Logger.debug("Launcher", "With args " + args);
-                Future<ProcessPool.ProcessResult> future = ProcessPool.getInstance().submit(EmbeddedLauncher.class, List.of(), args);
+                Future<ProcessPool.ProcessResult> future = ProcessPool.getInstance().submit(EmbeddedLauncher.class, jvmArgs, args);
                 // ArkPets core finalized.
                 if (!future.get().isSuccess()) {
                     int exitCode = future.get().exitValue();

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -8,6 +8,7 @@ import cn.harryh.arkpets.ArkHomeFX;
 import cn.harryh.arkpets.Const;
 import cn.harryh.arkpets.guitasks.CheckAppUpdateTask;
 import cn.harryh.arkpets.guitasks.GuiTask;
+import cn.harryh.arkpets.platform.WindowSystem;
 import cn.harryh.arkpets.utils.*;
 import cn.harryh.arkpets.utils.GuiComponents.*;
 import com.badlogic.gdx.graphics.Color;
@@ -302,19 +303,19 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
 
     private static ArrayList<NamedItem<Integer>> getWindowSystemItems() {
         ArrayList<NamedItem<Integer>> windowSystemItems = new ArrayList<>();
-        windowSystemItems.add(new NamedItem<>("自动", 0));
+        windowSystemItems.add(new NamedItem<>("自动", WindowSystem.AUTO.ordinal()));
         if (Platform.isWindows()) {
-            windowSystemItems.add(new NamedItem<>("User32", 1));
+            windowSystemItems.add(new NamedItem<>("User32", WindowSystem.USER32.ordinal()));
         }
         if (Platform.isLinux()) {
-            windowSystemItems.add(new NamedItem<>("X11", 2));
-            windowSystemItems.add(new NamedItem<>("Mutter", 3));
-            windowSystemItems.add(new NamedItem<>("KWin", 4));
+            windowSystemItems.add(new NamedItem<>("X11", WindowSystem.X11.ordinal()));
+            windowSystemItems.add(new NamedItem<>("Mutter", WindowSystem.MUTTER.ordinal()));
+            windowSystemItems.add(new NamedItem<>("KWin", WindowSystem.KWIN.ordinal()));
         }
         if (Platform.isMac()) {
-            windowSystemItems.add(new NamedItem<>("Quartz", 5));
+            windowSystemItems.add(new NamedItem<>("Quartz", WindowSystem.QUARTZ.ordinal()));
         }
-        windowSystemItems.add(new NamedItem<>("NULL", 6));
+        windowSystemItems.add(new NamedItem<>("NULL", WindowSystem.NULL.ordinal()));
         return windowSystemItems;
     }
 

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -188,10 +188,15 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
         configLoggingLevel.getSelectionModel().select(level);
 
         exploreLogDir.setOnMouseClicked(e -> {
-            // Only available in Windows OS
             try {
                 Logger.debug("Config", "Request to explore the log dir");
-                Runtime.getRuntime().exec("explorer logs");
+                if (Platform.isWindows()) {
+                    Runtime.getRuntime().exec("explorer logs");
+                } else if (Platform.isLinux()) {
+                    Runtime.getRuntime().exec("xdg-open logs");
+                } else if (Platform.isMac()) {
+                    Runtime.getRuntime().exec("open logs");
+                }
             } catch (IOException ex) {
                 Logger.warn("Config", "Exploring log dir failed");
             }

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -10,6 +10,7 @@ import cn.harryh.arkpets.guitasks.CheckAppUpdateTask;
 import cn.harryh.arkpets.guitasks.GuiTask;
 import cn.harryh.arkpets.utils.*;
 import cn.harryh.arkpets.utils.GuiComponents.*;
+import com.badlogic.gdx.graphics.Color;
 import com.jfoenix.controls.*;
 import com.sun.jna.Platform;
 import javafx.concurrent.ScheduledService;
@@ -41,6 +42,8 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
     private JFXComboBox<NamedItem<Integer>> configCanvasSize;
     @FXML
     private JFXComboBox<NamedItem<Integer>> configRenderOutline;
+    @FXML
+    private JFXComboBox<NamedItem<Integer>> configBackgroundColor;
     @FXML
     private JFXCheckBox configWindowTopmost;
     @FXML
@@ -144,6 +147,15 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
                 .selectValue(app.config.display_render_outline, "未知")
                 .setOnNonNullValueUpdated((observable, oldValue, newValue) -> {
                     app.config.display_render_outline = newValue.value();
+                    app.config.save();
+                });
+        new ComboBoxSetup<>(configBackgroundColor).setItems(new NamedItem<>("透明", 0x00000000),
+                        new NamedItem<>("绿色", 0x00ff00ff),
+                        new NamedItem<>("蓝色", 0x0000ffff),
+                        new NamedItem<>("品红色", 0xff00ffff))
+                .selectValue(Color.rgba8888(app.config.getBackgroundColor()), app.config.background_color + "（自定义）")
+                .setOnNonNullValueUpdated((observable, oldValue, newValue) -> {
+                    app.config.background_color = String.format("#%08X", newValue.value());
                     app.config.save();
                 });
         configWindowTopmost.setSelected(app.config.window_style_topmost);

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -11,6 +11,7 @@ import cn.harryh.arkpets.guitasks.GuiTask;
 import cn.harryh.arkpets.utils.*;
 import cn.harryh.arkpets.utils.GuiComponents.*;
 import com.jfoenix.controls.*;
+import com.sun.jna.Platform;
 import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
@@ -22,6 +23,7 @@ import org.apache.log4j.Level;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -59,6 +61,10 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
     private JFXCheckBox configWindowToolwindow;
     @FXML
     private JFXButton configWindowToolwindowHelp;
+    @FXML
+    private JFXComboBox<NamedItem<Integer>> configWindowSystem;
+    @FXML
+    private JFXButton configWindowSystemHelp;
     @FXML
     private Label aboutQueryUpdate;
     @FXML
@@ -261,6 +267,62 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
                 };
             }
         };
+
+        NamedItem<Integer>[] items = getWindowSystemItems().toArray(new NamedItem[0]);
+        new ComboBoxSetup<>(configWindowSystem).setItems(items)
+                .selectValue(app.config.window_system, "自动")
+                .setOnNonNullValueUpdated((observable, oldValue, newValue) -> {
+                    app.config.window_system = newValue.value();
+                    app.config.save();
+                });
+        new HandbookEntrance(app.body, configWindowSystemHelp) {
+            @Override
+            public Handbook getHandbook() {
+                return new ControlHandbook((Labeled) configWindowSystem.getParent().getChildrenUnmodifiable().get(0)) {
+                    @Override
+                    public String getContent() {
+                        return getWindowSystemInfo();
+                    }
+                };
+            }
+        };
+    }
+
+    private static ArrayList<NamedItem<Integer>> getWindowSystemItems() {
+        ArrayList<NamedItem<Integer>> windowSystemItems = new ArrayList<>();
+        windowSystemItems.add(new NamedItem<>("自动", 0));
+        if (Platform.isWindows()) {
+            windowSystemItems.add(new NamedItem<>("User32", 1));
+        }
+        if (Platform.isLinux()) {
+            windowSystemItems.add(new NamedItem<>("X11", 2));
+            windowSystemItems.add(new NamedItem<>("Mutter", 3));
+            windowSystemItems.add(new NamedItem<>("KWin", 4));
+        }
+        if (Platform.isMac()) {
+            windowSystemItems.add(new NamedItem<>("Quartz", 5));
+        }
+        windowSystemItems.add(new NamedItem<>("NULL", 6));
+        return windowSystemItems;
+    }
+
+    private static String getWindowSystemInfo() {
+        String content = "不同平台对于窗口查询、操作有不同的 API，除非你遇到了桌宠窗口的问题，否则通常不需要更改。以下是对 API 的简单介绍：\n";
+        if (Platform.isWindows()) {
+            content += "User32 —— Windows 窗口系统。\n";
+        }
+        if (Platform.isLinux()) {
+            content += """
+                    Mutter —— GNOME 环境，需要安装集成扩展。
+                    KWin —— KDE 环境，需要安装集成插件。
+                    X11 —— 通用 X11 环境支持，适用于 Xfce,Mate,LXDE 等环境。
+                    """;
+        }
+        if (Platform.isMac()) {
+            content += "Quartz —— MacOS Quartz 窗口系统。\n";
+        }
+        content += "NULL —— 空实现，桌宠不会有任何窗口交互。";
+        return content;
     }
 
     private void initAbout() {

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static cn.harryh.arkpets.ArkConfig.getWorkingDirectory;
 import static cn.harryh.arkpets.Const.*;
 
 
@@ -191,11 +192,11 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
             try {
                 Logger.debug("Config", "Request to explore the log dir");
                 if (Platform.isWindows()) {
-                    Runtime.getRuntime().exec("explorer logs");
+                    Runtime.getRuntime().exec(new String[]{"explorer",getWorkingDirectory()+"logs"});
                 } else if (Platform.isLinux()) {
-                    Runtime.getRuntime().exec("xdg-open logs");
+                    Runtime.getRuntime().exec(new String[]{"xdg-open",getWorkingDirectory()+"logs"});
                 } else if (Platform.isMac()) {
-                    Runtime.getRuntime().exec("open logs");
+                    Runtime.getRuntime().exec(new String[]{"open",getWorkingDirectory()+"logs"});
                 }
             } catch (IOException ex) {
                 Logger.warn("Config", "Exploring log dir failed");

--- a/desktop/src/cn/harryh/arkpets/utils/NetUtils.java
+++ b/desktop/src/cn/harryh/arkpets/utils/NetUtils.java
@@ -62,12 +62,14 @@ public class NetUtils {
      * @param url The URL to browse.
      */
     public static void browseWebpage(String url) {
-        try {
-            Logger.debug("Network", "Opening the URL " + url + " in the browser");
-            Desktop.getDesktop().browse(URI.create(url));
-        } catch (IOException e) {
-            Logger.error("Network", "Failed to open the URL in the browser, details see below.", e);
-        }
+        new Thread(() -> {
+            try {
+                Logger.debug("Network", "Opening the URL " + url + " in the browser");
+                Desktop.getDesktop().browse(URI.create(url));
+            } catch (IOException e) {
+                Logger.error("Network", "Failed to open the URL in the browser, details see below.", e);
+            }
+        }).start();
     }
 
 

--- a/docs/Thanks.md
+++ b/docs/Thanks.md
@@ -29,3 +29,4 @@ ArkPets附加说明文档
 |    [JNA](https://github.com/java-native-access/jna)     | Java Native Access 接口      |
 | [Alibaba FastJSON](https://github.com/alibaba/fastjson) | JSON 工具                    |
 |    [Apache log4j](https://logging.apache.org/log4j)     | 日志工具                       |
+|   [dbus-java](https://github.com/hypfvieh/dbus-java)    | D-Bus 通信接口                 |


### PR DESCRIPTION
为 ArkPets 加入实验性跨平台支持，以及其他小功能。

- [x] GNOME Mutter 支持（Wayland 和 X11）
- [x] KDE KWin 支持（Wayland 和 X11） 
- [x] 通用 X11 支持（EWMH 窗口管理器标准，性能有待优化）
- [ ] macOS 支持
- [x] 无窗口交互模式（桌宠没有任何与窗口的交互）
- [x] 自定义背景色（方便其他软件采集和使用）
- [x] 自定义工作目录（方便将主程序和资源存放在不同的位置上）
- [x] 升级 LWJGL 版本（解决部分跨平台兼容问题）
- [x] 跨平台托盘图标，打开日志目录
- [x] 基于 GLSL 的透明度和兼容性调整  
- [ ] 自动安装桌面集成
- [ ] 跨平台打包
- [ ] 跨平台开机启动

其中 Mutter 和 KWin 支持使用了 [dbus-java](https://github.com/hypfvieh/dbus-java)，部分功能（如透明模式、工具窗口）尚未实现，需要安装[桌面集成](https://github.com/litwak913/Ark-Pets-Integration)。

macOS 支持计划使用 [java-objc-bridge](https://github.com/shannah/Java-Objective-C-Bridge)。

将在全部实现后合并。