### PR TITLE
Fixed crash caused by unexpected socket message

### DIFF
--- a/core/src/cn/harryh/arkpets/concurrent/PortUtils.java
+++ b/core/src/cn/harryh/arkpets/concurrent/PortUtils.java
@@ -3,6 +3,8 @@
  */
 package cn.harryh.arkpets.concurrent;
 
+import cn.harryh.arkpets.utils.Logger;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONObject;
 
 import java.io.BufferedReader;
@@ -34,6 +36,8 @@ public class PortUtils {
                 in.close();
                 if (socketData.operation == SocketData.Operation.HANDSHAKE_RESPONSE)
                     return serverPort;
+            } catch (JSONException ignored) {
+                Logger.error("SocketServer", String.format("Port %d is already occupied and is not occupied by ArkPets", serverPort));
             } catch (IOException ignored) {
             }
         }


### PR DESCRIPTION
Fixed the issue that the core would report an `JSONException` when the SocketServer port was occupied by another program.

Stacktrace:
```
16:30:21,184 [ERROR] System: An fatal error occurs in the runtime of Lwjgl3Application, details see below.
com.alibaba.fastjson2.JSONException: illegal fieldName input$, offset 1, character $, line 1, column 2, fastjson-version 2.0.39 $ (    
	at com.alibaba.fastjson2.JSONReaderASCII.readFieldNameHashCode(JSONReaderASCII.java:377)
	at com.alibaba.fastjson2.reader.ObjectReaderNoneDefaultConstructor.readObject(ObjectReaderNoneDefaultConstructor.java:242)
	at com.alibaba.fastjson2.JSON.parseObject(JSON.java:726)
	at com.alibaba.fastjson2.JSONObject.parseObject(JSONObject.java:1987)
	at cn.harryh.arkpets.concurrent.PortUtils.getServerPort(PortUtils.java:32)
	at cn.harryh.arkpets.concurrent.SocketClient.connect(SocketClient.java:47)
	at cn.harryh.arkpets.tray.MemberTrayImpl.<init>(MemberTrayImpl.java:67)
	at cn.harryh.arkpets.ArkPets.create(ArkPets.java:103)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.initializeListener(Lwjgl3Window.java:416)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:366)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:192)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:166)
	at cn.harryh.arkpets.EmbeddedLauncher.main(EmbeddedLauncher.java:87)
```