### PR TITLE
Fixed skeleton animation process

### DIFF
--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -288,6 +288,7 @@ public class ArkChar {
                     }
                 }
             }
+            skeleton.setToSetupPose();
         }
         // Take down the snapshot from the rendered FBO
         Pixmap snapshot = Pixmap.createFromFrameBuffer(0, 0, camera.getWidth(), camera.getHeight());


### PR DESCRIPTION
修复了 #81 因预处理动画后未重置骨骼，导致部分模型出现异常的问题。

原因：`AnimationState.clearTrack` 方法调用后，不会重置骨骼，而是保留骨骼的当前动作。
![网页截图 2024-10-21](https://github.com/user-attachments/assets/c7d7941d-0611-43e2-89bb-9c7bc23a1e12)

修复后效果：
![屏幕截图 2024-10-20](https://github.com/user-attachments/assets/3b401135-1fc5-4afd-8b39-eac721de25d2)

