### PR TITLE
Add download option customization and MirrorChyan source

### DIFF
--- a/assets/ArkPetsConfigDefault.json
+++ b/assets/ArkPetsConfigDefault.json
@@ -17,6 +17,7 @@
     "display_margin_bottom":0,
     "display_multi_monitors":true,
     "display_scale":1.0,
+    "download_mc_cdk":"",
     "eco_mode":false,
     "initial_position_x":0.2,
     "initial_position_y":0.2,

--- a/assets/UI/DownloadDialog.fxml
+++ b/assets/UI/DownloadDialog.fxml
@@ -50,7 +50,7 @@
                 <String fx:value="btn-iconified"/>
             </styleClass>
         </JFXButton>
-        <Label styleClass="dialog-title-label" text="下载选项"/>
+        <Label styleClass="dialog-title-label" text="下载策略"/>
     </HBox>
     <Separator layoutX="272.0" layoutY="130.0" orientation="VERTICAL" prefHeight="225.0"
                AnchorPane.bottomAnchor="15.0"/>

--- a/assets/UI/DownloadDialog.fxml
+++ b/assets/UI/DownloadDialog.fxml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2022-2025, Harry Huang
+    At GPL-3.0 License
+-->
+
+<?import com.jfoenix.controls.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.shape.SVGPath?>
+<?import javafx.scene.text.Font?>
+<?import java.lang.String?>
+<AnchorPane fx:id="dialog" prefHeight="325.0" prefWidth="550.0" styleClass="wrapper" stylesheets="@Main.css"
+            xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="cn.harryh.arkpets.controllers.DownloadDialog">
+    <HBox spacing="10.0" styleClass="dialog-oper-bar" AnchorPane.leftAnchor="-15.0" AnchorPane.rightAnchor="-15.0"
+          AnchorPane.topAnchor="-15.0">
+        <padding>
+            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+        </padding>
+        <Pane visible="false" HBox.hgrow="ALWAYS"/>
+        <VBox alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="50.0" prefWidth="355.0"
+              styleClass="tool-bar-mask">
+            <Label text="请选择下载源：">
+                <font>
+                    <Font name="System Bold" size="18.0"/>
+                </font>
+            </Label>
+            <Label text="您希望从哪个渠道下载资源？"/>
+        </VBox>
+    </HBox>
+    <HBox prefHeight="50.0" prefWidth="125.0" styleClass="dialog-title-bar" AnchorPane.leftAnchor="-25.0"
+          AnchorPane.topAnchor="-25.0">
+        <padding>
+            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+        </padding>
+        <JFXButton fx:id="dialogReturn" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false"
+                   prefHeight="32.0" prefWidth="32.0" text=" ">
+            <graphic>
+                <AnchorPane prefHeight="32.0" prefWidth="32.0" styleClass="btn-icon">
+                    <SVGPath
+                            content="m10.978 14.999v3.251c0 .412-.335.75-.752.75-.188 0-.375-.071-.518-.206-1.775-1.685-4.945-4.692-6.396-6.069-.2-.189-.312-.452-.312-.725 0-.274.112-.536.312-.725 1.451-1.377 4.621-4.385 6.396-6.068.143-.136.33-.207.518-.207.417 0 .752.337.752.75v3.251h9.02c.531 0 1.002.47 1.002 1v3.998c0 .53-.471 1-1.002 1z"
+                            scaleX="1.75" scaleY="1.75" translateX="30.0" translateY="-2.5"/>
+                </AnchorPane>
+            </graphic>
+            <styleClass>
+                <String fx:value="btn-plain-light"/>
+                <String fx:value="btn-iconified"/>
+            </styleClass>
+        </JFXButton>
+        <Label styleClass="dialog-title-label" text="下载选项"/>
+    </HBox>
+    <Separator layoutX="272.0" layoutY="130.0" orientation="VERTICAL" prefHeight="225.0"
+               AnchorPane.bottomAnchor="15.0"/>
+    <VBox alignment="TOP_CENTER" layoutX="309.0" layoutY="79.0" prefHeight="235.0" prefWidth="235.0" spacing="5.0"
+          AnchorPane.bottomAnchor="10.0" AnchorPane.rightAnchor="10.0">
+        <padding>
+            <Insets left="5.0" right="5.0"/>
+        </padding>
+        <HBox alignment="TOP_CENTER" spacing="5.0">
+            <Label text="从 Mirror 酱下载" textAlignment="CENTER">
+                <font>
+                    <Font name="System Bold" size="16.0"/>
+                </font>
+            </Label>
+            <Label fx:id="mcIndicator" managed="false" styleClass="info-type-badge" text="当前采用" visible="false">
+            </Label>
+        </HBox>
+        <Label minHeight="75.0"
+               text="Mirror 酱是一个第三方应用分发平台，提供高效的资源下载服务，由用户付费使用，其收益与我们开发者共享。"
+               textAlignment="CENTER" wrapText="true"/>
+        <Label fx:id="mcPurchase" styleClass="config-hyper-link" text="还未拥有 CDK 密钥？点我前往购买！"
+               textAlignment="CENTER" wrapText="true"/>
+        <Pane prefHeight="200.0" prefWidth="200.0"/>
+        <Label minHeight="20.0" text="请输入 Mirror 酱 CDK 密钥："/>
+        <JFXTextField fx:id="mcCdkInput"/>
+        <Pane prefHeight="200.0" prefWidth="200.0"/>
+        <JFXButton fx:id="mcConfirm" mnemonicParsing="false" styleClass="btn-primary" text="肯定是这边厉害"/>
+    </VBox>
+    <VBox alignment="TOP_CENTER" layoutX="41.0" layoutY="130.0" prefHeight="235.0" prefWidth="235.0" spacing="7.5"
+          AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0">
+        <padding>
+            <Insets left="5.0" right="5.0"/>
+        </padding>
+        <HBox alignment="TOP_CENTER" spacing="5.0">
+            <Label text="从公共源下载" textAlignment="CENTER">
+                <font>
+                    <Font name="System Bold" size="16.0"/>
+                </font>
+            </Label>
+            <Label fx:id="psIndicator" managed="false" styleClass="info-type-badge" text="当前采用" visible="false">
+            </Label>
+        </HBox>
+        <Label minHeight="75.0"
+               text="从公共互联网中下载资源是完全免费的，但是连接可能不稳定。下载速度太慢时，您可能需要取消下载并重新尝试。"
+               textAlignment="CENTER" wrapText="true"/>
+        <Pane prefHeight="200.0" prefWidth="200.0"/>
+        <JFXButton fx:id="psConfirm" mnemonicParsing="false" styleClass="btn-primary" text="我寻思这边能行"/>
+    </VBox>
+</AnchorPane>

--- a/assets/UI/SettingsModule.fxml
+++ b/assets/UI/SettingsModule.fxml
@@ -120,10 +120,9 @@
                 <HBox>
                     <JFXCheckBox fx:id="configEcoMode" mnemonicParsing="false" text="长时间未交互时降低帧率"/>
                 </HBox>
-                <Separator/>
                 <HBox spacing="20.0">
                     <Label text="日志级别"/>
-                    <JFXComboBox fx:id="configLoggingLevel" prefWidth="100.0"/>
+                    <JFXComboBox fx:id="configLoggingLevel" prefWidth="120.0"/>
                     <JFXButton fx:id="exportLog" alignment="TOP_CENTER" minHeight="-Infinity" minWidth="-Infinity"
                                mnemonicParsing="false" prefWidth="82.5" text="导出日志">
                         <graphic>
@@ -139,10 +138,16 @@
                         </styleClass>
                     </JFXButton>
                 </HBox>
+                <Separator/>
+                <Label styleClass="config-group-title" text="网络设置"/>
+                <HBox spacing="20.0">
+                    <Label text="下载策略"/>
+                    <JFXTextField fx:id="configNetworkSource" prefWidth="120.0" text="-"/>
+                </HBox>
                 <HBox spacing="20.0">
                     <Label text="网络代理（仅本次有效）"/>
-                    <JFXTextField fx:id="configNetworkAgent" prefHeight="23.0" prefWidth="100.0"/>
-                    <Label fx:id="configNetworkAgentStatus" text="-"/>
+                    <JFXTextField fx:id="configNetworkProxy" prefHeight="23.0" prefWidth="120.0"/>
+                    <Label fx:id="configNetworkProxyStatus" text="-"/>
                 </HBox>
                 <Separator/>
                 <Label styleClass="config-group-title" text="关于软件"/>

--- a/core/src/cn/harryh/arkpets/ArkConfig.java
+++ b/core/src/cn/harryh/arkpets/ArkConfig.java
@@ -6,6 +6,7 @@ package cn.harryh.arkpets;
 import cn.harryh.arkpets.transitions.EasingFunction;
 import cn.harryh.arkpets.utils.IOUtils.FileUtil;
 import cn.harryh.arkpets.utils.Logger;
+import cn.harryh.arkpets.utils.SecretUtils;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -19,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -68,6 +70,8 @@ public class ArkConfig implements Serializable {
     public boolean      display_multi_monitors;
     /** @since ArkPets 1.0 */ @JSONField(defaultValue = "1.0")
     public float        display_scale;
+    /** @since ArkPets 3.9 */ @JSONField()
+    public String       download_mc_cdk;
     /** @since ArkPets 3.9 */ @JSONField(defaultValue = "false")
     public boolean      eco_mode;
     /** @since ArkPets 3.2 */ @JSONField(defaultValue = "0.2")
@@ -139,6 +143,40 @@ public class ArkConfig implements Serializable {
         return isNewcomer;
     }
 
+    /** Gets the MirrorChyan CDK.
+     * @return The decrypted CDK, or {@code null} if the CDK is not set or decryption failed.
+     */
+    @JSONField(serialize = false)
+    public String getMcCdk() {
+        if (download_mc_cdk != null && !download_mc_cdk.isEmpty()) {
+            try {
+                String result = new SecretUtils.WeakEncryptionV0().decrypt(download_mc_cdk);
+                Logger.debug("Config", "Decrypt MirrorChyan CDK okay");
+                return result;
+            } catch (GeneralSecurityException e) {
+                Logger.error("Config", "Failed to decrypt MirrorChyan CDK, details see below.", e);
+            }
+        }
+        return null;
+    }
+
+    /** Sets the MirrorChyan CDK.
+     * @param string The CDK to set. If the string is {@code null} or empty, the CDK will be cleared.
+     */
+    public void setMcCdk(String string) throws GeneralSecurityException {
+        if (string != null && !string.isEmpty()) {
+            try {
+                download_mc_cdk = new SecretUtils.WeakEncryptionV0().encrypt(string);
+                Logger.debug("Config", "Encrypt MirrorChyan CDK okay");
+                return;
+            } catch (GeneralSecurityException e) {
+                Logger.error("Config", "Failed to encrypt MirrorChyan CDK, details see below.", e);
+                throw e;
+            }
+        }
+        download_mc_cdk = "";
+    }
+
     /** Gets the custom ArkConfig object by reading the external config file.
      * If the external config file does not exist, a default config file will be generated.
      * @return An ArkConfig object. {@code null} if failed.
@@ -191,7 +229,7 @@ public class ArkConfig implements Serializable {
         }
     }
 
-    /** @see com.badlogic.gdx.graphics.Color
+    /** @see Color
      */
     public static Color getGdxColorFrom(String string) {
         Color color;

--- a/core/src/cn/harryh/arkpets/Const.java
+++ b/core/src/cn/harryh/arkpets/Const.java
@@ -96,15 +96,12 @@ public final class Const {
         public static final String urlOfficial      = "https://arkpets.harryh.cn/p/arkpets/?from=client";
         public static final String urlReadme        = "https://github.com/isHarryh/Ark-Pets#readme";
         public static final String urlLicense       = "https://github.com/isHarryh/Ark-Pets";
-        public static final String urlModelsZip     = "isHarryh/Ark-Models/archive/refs/heads/main.zip";
-        public static final String urlModelsData    = "isHarryh/Ark-Models/main/models_data.json";
+        public static final String urlMirrorChyan   = "https://mirrorchyan.com/?source=ArkPetsGui";
         public static final String tempDirPath      = "temp/";
         public static final String fileModelsZipName            = "ArkModels";
         public static final String fileModelsDataPath           = "models_data.json";
         public static final String tempModelsUnzipDirPath       = tempDirPath + "models_unzipped/";
         public static final String tempModelsZipCachePath       = tempDirPath + fileModelsZipName + ".zip";
-        public static final String tempQueryVersionCachePath    = tempDirPath + "ApiQueryVersionCache";
-        public static final String tempQueryAnnounceCachePath   = tempDirPath + "ApiQueryAnnounceCache";
     }
 
 

--- a/core/src/cn/harryh/arkpets/utils/SecretUtils.java
+++ b/core/src/cn/harryh/arkpets/utils/SecretUtils.java
@@ -1,0 +1,147 @@
+/** Copyright (c) 2022-2025, Harry Huang
+ * At GPL-3.0 License
+ */
+package cn.harryh.arkpets.utils;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import java.util.Enumeration;
+
+
+public class SecretUtils {
+    public interface SecretAlgorithm {
+        String encrypt(String plaintext) throws GeneralSecurityException;
+        String decrypt(String encoded) throws GeneralSecurityException;
+    }
+
+
+    public static class WeakEncryptionV0 implements SecretAlgorithm {
+        private final String deviceBinding;
+        private static final Charset charset = StandardCharsets.UTF_8;
+
+        public WeakEncryptionV0() {
+            deviceBinding = getDeviceBindingKey();
+        }
+
+        private static String getPrimaryMacAddress() {
+            try {
+                Enumeration<NetworkInterface> eni = NetworkInterface.getNetworkInterfaces();
+                while (eni.hasMoreElements()) {
+                    NetworkInterface ni = eni.nextElement();
+                    if (ni.isUp() && !ni.isLoopback() && !ni.isVirtual()) {
+                        byte[] mac = ni.getHardwareAddress();
+                        if (mac != null) {
+                            StringBuilder sb = new StringBuilder();
+                            for (byte b : mac)
+                                sb.append(String.format("%02X:", b));
+                            return sb.substring(0, sb.length() - 1);
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+            return "unknown_mac";
+        }
+
+        private static String getHostname() {
+            try {
+                return InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException ignored) {
+            }
+            return  "unknown_hostname";
+        }
+
+        private static String getDeviceBindingKey() {
+            return System.getProperty("user.name") + ","
+                    + System.getProperty("user.home") + ";"
+                    + getHostname() + ","
+                    + getPrimaryMacAddress() + ";"
+                    + System.getProperty("os.name") + ","
+                    + System.getProperty("os.arch") + ";";
+        }
+
+        private static SecretKey generateKey(String passphrase, byte[] salt) {
+            int iters = 65536;
+            int keyLength = 256;
+            SecretKey key;
+            try {
+                KeySpec spec = new PBEKeySpec(passphrase.toCharArray(), salt, iters, keyLength);
+                key = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec);
+            } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+            return new SecretKeySpec(key.getEncoded(), "AES");
+        }
+
+        @Override
+        public String encrypt(String plaintext) throws GeneralSecurityException {
+            try {
+                byte[] salt = SecureRandom.getInstanceStrong().generateSeed(16);
+                byte[] iv = SecureRandom.getInstanceStrong().generateSeed(12);
+
+                Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                SecretKey key = generateKey(deviceBinding, salt);
+                GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+                cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+
+                byte[] ciphertext = cipher.doFinal(plaintext.getBytes(charset));
+
+                ByteBuffer buffer = ByteBuffer.allocate(salt.length + iv.length + ciphertext.length);
+                buffer.put(salt);
+                buffer.put(iv);
+                buffer.put(ciphertext);
+
+                return Base64.getEncoder().encodeToString(buffer.array());
+
+            } catch (NoSuchAlgorithmException e){
+                throw new RuntimeException(e);
+            } catch (GeneralSecurityException e) {
+                throw new GeneralSecurityException("Encryption failed");
+            }
+        }
+
+        @Override
+        public String decrypt(String encoded) throws GeneralSecurityException {
+            try {
+                byte[] data = Base64.getDecoder().decode(encoded);
+                ByteBuffer buffer = ByteBuffer.wrap(data);
+
+                byte[] salt = new byte[16];
+                byte[] iv = new byte[12];
+                byte[] ciphertext = new byte[data.length - 16 - 12];
+                buffer.get(salt);
+                buffer.get(iv);
+                buffer.get(ciphertext);
+
+                Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                SecretKey key = generateKey(deviceBinding, salt);
+                GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+                cipher.init(Cipher.DECRYPT_MODE, key, spec);
+
+                byte[] plaintext = cipher.doFinal(ciphertext);
+                return new String(plaintext, charset);
+
+            } catch (NoSuchAlgorithmException e){
+                throw new RuntimeException(e);
+            } catch (GeneralSecurityException e) {
+                throw new GeneralSecurityException("Decryption failed");
+            }
+        }
+    }
+}

--- a/desktop/src/cn/harryh/arkpets/controllers/DownloadDialog.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/DownloadDialog.java
@@ -13,6 +13,8 @@ import cn.harryh.arkpets.utils.Logger;
 import cn.harryh.arkpets.utils.StringUtils;
 import com.alibaba.fastjson.JSONObject;
 import com.jfoenix.controls.*;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
@@ -32,7 +34,7 @@ public final class DownloadDialog implements DialogController<ArkHomeFX> {
     @FXML
     private Label mcIndicator;
     @FXML
-    public Label mcPurchase;
+    private Label mcPurchase;
     @FXML
     private JFXTextField mcCdkInput;
     @FXML
@@ -45,12 +47,16 @@ public final class DownloadDialog implements DialogController<ArkHomeFX> {
     private ArkHomeFX app;
 
     private Runnable afterConfirm;
+    private BooleanProperty isMc;
 
     private static final Pattern cdkPattern = Pattern.compile("[\\w\\-]{4,256}");
 
     @Override
     public void initializeWith(ArkHomeFX app) {
         this.app = app;
+
+        afterConfirm = null;
+        isMc = new SimpleBooleanProperty(app.config.getMcCdk() != null);
 
         initPs();
         initMc();
@@ -78,12 +84,14 @@ public final class DownloadDialog implements DialogController<ArkHomeFX> {
             }
         }
         if (app.config.getMcCdk() != null) {
+            isMc.setValue(true);
             mcIndicator.setManaged(true);
             mcIndicator.setVisible(true);
             psIndicator.setManaged(false);
             psIndicator.setVisible(false);
             mcCdkInput.setPromptText("点击下方按钮以验证当前 CDK");
         } else {
+            isMc.setValue(false);
             mcIndicator.setManaged(false);
             mcIndicator.setVisible(false);
             psIndicator.setManaged(true);
@@ -92,11 +100,16 @@ public final class DownloadDialog implements DialogController<ArkHomeFX> {
         }
     }
 
+    public BooleanProperty getIsMcProperty() {
+        return isMc;
+    }
+
     private void initPs() {
         psConfirm.setOnAction(e -> {
             try {
                 app.config.setMcCdk("");
                 app.config.save();
+                isMc.setValue(false);
             } catch (GeneralSecurityException ignored) {
             }
             Logger.info("DownloadDialog", "Chose the public source");
@@ -141,6 +154,7 @@ public final class DownloadDialog implements DialogController<ArkHomeFX> {
                     value.raiseForCode();
                     app.config.setMcCdk(cdk);
                     app.config.save();
+                    isMc.setValue(true);
 
                     String exp = StringUtils.getSimpleTimeString(value.getCDKExpiredTime());
                     Logger.info("DownloadDialog", "Accepted CDK, expires at: " + exp);

--- a/desktop/src/cn/harryh/arkpets/controllers/DownloadDialog.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/DownloadDialog.java
@@ -1,0 +1,176 @@
+/** Copyright (c) 2022-2025, Harry Huang
+ * At GPL-3.0 License
+ */
+package cn.harryh.arkpets.controllers;
+
+import cn.harryh.arkpets.ArkHomeFX;
+import cn.harryh.arkpets.Const;
+import cn.harryh.arkpets.guitasks.GuiTask.GuiTaskStyle;
+import cn.harryh.arkpets.guitasks.requests.McCheckAppUpdateTask;
+import cn.harryh.arkpets.network.api.McQueryVersion;
+import cn.harryh.arkpets.utils.GuiPrefabs;
+import cn.harryh.arkpets.utils.Logger;
+import cn.harryh.arkpets.utils.StringUtils;
+import com.alibaba.fastjson.JSONObject;
+import com.jfoenix.controls.*;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.AnchorPane;
+
+import java.security.GeneralSecurityException;
+import java.util.regex.Pattern;
+
+
+public final class DownloadDialog implements DialogController<ArkHomeFX> {
+    @FXML
+    private AnchorPane dialog;
+    @FXML
+    private JFXButton dialogReturn;
+
+    @FXML
+    private Label mcIndicator;
+    @FXML
+    public Label mcPurchase;
+    @FXML
+    private JFXTextField mcCdkInput;
+    @FXML
+    private JFXButton mcConfirm;
+    @FXML
+    private Label psIndicator;
+    @FXML
+    private JFXButton psConfirm;
+
+    private ArkHomeFX app;
+
+    private Runnable afterConfirm;
+
+    private static final Pattern cdkPattern = Pattern.compile("[\\w\\-]{4,256}");
+
+    @Override
+    public void initializeWith(ArkHomeFX app) {
+        this.app = app;
+
+        initPs();
+        initMc();
+    }
+
+    @Override
+    public AnchorPane getDialogPane() {
+        return dialog;
+    }
+
+    @Override
+    public JFXButton getReturnButton() {
+        return dialogReturn;
+    }
+
+    @Override
+    public void notifyDialogOpened(Object data) {
+        afterConfirm = null;
+        if (data != null) {
+            if (data instanceof Runnable runnable) {
+                // The runnable will be started if any confirm action is triggered
+                afterConfirm = runnable;
+            } else {
+                throw new IllegalArgumentException("Invalid data type");
+            }
+        }
+        if (app.config.getMcCdk() != null) {
+            mcIndicator.setManaged(true);
+            mcIndicator.setVisible(true);
+            psIndicator.setManaged(false);
+            psIndicator.setVisible(false);
+            mcCdkInput.setPromptText("点击下方按钮以验证当前 CDK");
+        } else {
+            mcIndicator.setManaged(false);
+            mcIndicator.setVisible(false);
+            psIndicator.setManaged(true);
+            psIndicator.setVisible(true);
+            mcCdkInput.setPromptText("请在这里输入或粘贴 CDK");
+        }
+    }
+
+    private void initPs() {
+        psConfirm.setOnAction(e -> {
+            try {
+                app.config.setMcCdk("");
+                app.config.save();
+            } catch (GeneralSecurityException ignored) {
+            }
+            Logger.info("DownloadDialog", "Chose the public source");
+
+            triggerReturnActionCallback(new ActionEvent(this, null));
+            if (afterConfirm != null)
+                afterConfirm.run();
+        });
+    }
+
+    private void initMc() {
+        mcPurchase.setOnMouseClicked(e -> app.popBrowser(Const.PathConfig.urlMirrorChyan));
+        mcCdkInput.setOnKeyPressed(e -> {
+            if (e.getCode().getName().equals(KeyCode.ENTER.getName()))
+                submitMcCdk();
+        });
+        mcConfirm.setOnAction(e -> submitMcCdk());
+    }
+
+    private void submitMcCdk() {
+        String oldCdk = app.config.getMcCdk();
+        String input = mcCdkInput.getText().strip();
+        String cdk = input.isEmpty() && oldCdk != null ? oldCdk : input;
+
+        if (cdk.isEmpty()) {
+            mcCdkInput.clear();
+            Logger.debug("DownloadDialog", "Empty CDK input");
+            return;
+        }
+        if (!cdkPattern.matcher(cdk).matches()) {
+            mcCdkInput.clear();
+            Logger.debug("DownloadDialog", "Invalid CDK input");
+            return;
+        }
+
+        Logger.info("DownloadDialog", "Verifying CDK");
+        new McCheckAppUpdateTask(app.body, GuiTaskStyle.COMMON, cdk) {
+            @Override
+            protected void onReceivedData(JSONObject json) {
+                McQueryVersion value = json.toJavaObject(McQueryVersion.class);
+                try {
+                    value.raiseForCode();
+                    app.config.setMcCdk(cdk);
+                    app.config.save();
+
+                    String exp = StringUtils.getSimpleTimeString(value.getCDKExpiredTime());
+                    Logger.info("DownloadDialog", "Accepted CDK, expires at: " + exp);
+                    mcCdkInput.clear();
+
+                    if (afterConfirm != null) {
+                        GuiPrefabs.Dialogs.createConfirmDialog(app.body,
+                                GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_SUCCESS_ALT, GuiPrefabs.COLOR_SUCCESS),
+                                "Mirror 酱准备就绪",
+                                "CDK 验证完成！是否继续下一步？",
+                                "CDK 会在本地加密存储，此 CDK 的有效期至 " + exp,
+                                afterConfirm).show();
+                    } else {
+                        GuiPrefabs.Dialogs.createCommonDialog(app.body,
+                                GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_SUCCESS_ALT, GuiPrefabs.COLOR_SUCCESS),
+                                "Mirror 酱准备就绪",
+                                "CDK 验证完成！以后下载资源会自动采用此 CDK",
+                                "CDK 会在本地加密存储，此 CDK 的有效期至 " + exp,
+                                null).show();
+                    }
+
+                    triggerReturnActionCallback(new ActionEvent(this, null));
+                } catch (McQueryVersion.McException e) {
+                    Logger.error("DownloadDialog", "Invalid CDK, " + e.getMessage());
+                    GuiPrefabs.Dialogs.createErrorDialog(app.body, e).show();
+                } catch (GeneralSecurityException e) {
+                    Logger.error("DownloadDialog", "Failed to save CDK");
+                    GuiPrefabs.Dialogs.createErrorDialog(app.body, e).show();
+                }
+            }
+        }.start();
+    }
+}

--- a/desktop/src/cn/harryh/arkpets/controllers/ModelsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/ModelsModule.java
@@ -360,7 +360,19 @@ public final class ModelsModule implements Controller<ArkHomeFX> {
             /* Foreground check models update */
             if (!app.modelsModule.initModelsDataset(true))
                 return;
-            new DownloadModelDatasetTask(app.body, GuiTask.GuiTaskStyle.COMMON).start();
+            Logger.info("ModelManager", "Attempting checking model repo update by MirrorChyan");
+            checkModelUpdateByMc(() -> {
+                Logger.info("ModelManager", "Attempting checking model repo update by dataset file");
+                checkModelUpdateByDataset(() -> {
+                    Logger.error("ModelManager", "All approaches to check model repo update failed");
+                    GuiPrefabs.Dialogs.createCommonDialog(app.body,
+                            GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_DANGER, GuiPrefabs.COLOR_DANGER),
+                            "检查模型更新",
+                            "尝试了两种渠道都未能检查更新",
+                            "这可能是网络原因导致的，详情参见日志。",
+                            null).show();
+                });
+            });
         });
 
         modelFetch.setOnAction(modelFetchEventHandler);
@@ -732,6 +744,76 @@ public final class ModelsModule implements Controller<ArkHomeFX> {
                 app.dialogs.popDialog("downloadDialog", (Runnable) () -> assertDownloadSource(false, onDone));
             else if (onDone != null)
                 onDone.run();
+        }
+    }
+
+    private void checkModelUpdateByMc(Runnable onFail) {
+        new McCheckModelsUpdateTask(app.body, GuiTask.GuiTaskStyle.COMMON, "") {
+            @Override
+            protected void onReceivedData(JSONObject json) {
+                McQueryVersion value = json.toJavaObject(McQueryVersion.class);
+                try {
+                    value.raiseForCode();
+                    checkModelUpdateByMD5(value.data.version_name);
+                } catch (McQueryVersion.McException | IOException e) {
+                    this.onFailed(e);
+                }
+            }
+
+            @Override
+            protected void onFailed(Throwable e) {
+                Logger.error("ModelManager", "Model repo version check (mc) failed, details see below.", e);
+                if (onFail != null)
+                    onFail.run();
+            }
+        }.start();
+    }
+
+    private void checkModelUpdateByDataset(Runnable onFail) {
+        new DownloadModelDatasetTask(app.body, GuiTask.GuiTaskStyle.COMMON) {
+            @Override
+            protected void onDownloadedFile(File file) {
+                try {
+                    String remoteMD5 = IOUtils.FileUtil.getMD5(file);
+                    checkModelUpdateByMD5(remoteMD5);
+                } catch (IOException e) {
+                    this.onFailed(e);
+                }
+            }
+
+            @Override
+            protected void onFailed(Throwable e) {
+                Logger.error("ModelManager", "Model repo version check (dataset) failed, details see below.", e);
+                if (onFail != null)
+                    onFail.run();
+            }
+        }.start();
+    }
+
+    private void checkModelUpdateByMD5(String remoteMD5) throws IOException {
+        if (!app.modelsModule.initModelsDataset(true))
+            return;
+        // Compare the remote models dataset and the local models dataset by their MD5
+        String localMD5 = IOUtils.FileUtil.getMD5(new File(PathConfig.fileModelsDataPath));
+        String detail = "本地摘要值：" + localMD5 + "\n远程摘要值：" + remoteMD5;
+        if (localMD5.equals(remoteMD5)) {
+            // Same result: no update
+            Logger.info("ModelManager", "Model repo version check finished (up-to-dated)");
+            GuiPrefabs.Dialogs.createCommonDialog(app.body,
+                    GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_SUCCESS_ALT, GuiPrefabs.COLOR_SUCCESS),
+                    "检查模型更新",
+                    "无需进行模型库更新",
+                    "本地模型库的版本与远程模型库的一致。",
+                    "提示：远程模型库的版本不一定和游戏官方同步更新。\n\n" + detail).show();
+        } else {
+            // Different result: has update
+            GuiPrefabs.Dialogs.createCommonDialog(app.body,
+                    GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_INFO_ALT, GuiPrefabs.COLOR_INFO),
+                    "检查模型更新",
+                    "模型库似乎有更新！",
+                    "您可以 [重新下载] 模型，以更新模型库版本。",
+                    detail).show();
+            Logger.info("ModelManager", "Model repo version check finished (not up-to-dated)");
         }
     }
 }

--- a/desktop/src/cn/harryh/arkpets/controllers/ModelsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/ModelsModule.java
@@ -10,6 +10,9 @@ import cn.harryh.arkpets.assets.ModelsDataset;
 import cn.harryh.arkpets.guitasks.*;
 import cn.harryh.arkpets.guitasks.requests.DownloadModelDatasetTask;
 import cn.harryh.arkpets.guitasks.requests.DownloadModelsTask;
+import cn.harryh.arkpets.guitasks.requests.McCheckModelsUpdateTask;
+import cn.harryh.arkpets.network.SourceStrategy;
+import cn.harryh.arkpets.network.api.McQueryVersion;
 import cn.harryh.arkpets.utils.GuiComponents.NoticeBar;
 import cn.harryh.arkpets.utils.GuiPrefabs;
 import cn.harryh.arkpets.utils.IOUtils;
@@ -326,7 +329,7 @@ public final class ModelsModule implements Controller<ArkHomeFX> {
         EventHandler<ActionEvent> modelFetchEventHandler = e -> {
             /* Foreground fetch models */
             // Go to [Step 1/3]:
-            new DownloadModelsTask(app.body, GuiTask.GuiTaskStyle.COMMON) {
+            DownloadModelsTask task = new DownloadModelsTask(app.body, GuiTask.GuiTaskStyle.COMMON) {
                 @Override
                 protected void onDownloadedFile(File file) {
                     // Go to [Step 2/3]:
@@ -348,7 +351,9 @@ public final class ModelsModule implements Controller<ArkHomeFX> {
                         }
                     }.start();
                 }
-            }.start();
+            };
+
+            assertDownloadSource(true, task::start);
         };
 
         modelUpdate.setOnAction(e -> {
@@ -693,6 +698,40 @@ public final class ModelsModule implements Controller<ArkHomeFX> {
         } else {
             // Loaded:
             return true;
+        }
+    }
+
+    private void assertDownloadSource(boolean doDoubleCheck, Runnable onDone) {
+        SourceStrategy.getStrategy("ModelDownload").unsetPrimarySource();
+        String cdk;
+        if ((cdk = app.config.getMcCdk()) != null) {
+            Logger.debug("ModelManager", "Attempting using CDK to fetch resource");
+            new McCheckModelsUpdateTask(app.body, GuiTask.GuiTaskStyle.STRICT, cdk) {
+                @Override
+                protected void onReceivedData(JSONObject json) {
+                    McQueryVersion value = json.toJavaObject(McQueryVersion.class);
+                    try {
+                        value.raiseForCode();
+                        SourceStrategy.getStrategy("ModelDownload").setPrimarySource("MirrorChyan", value.data.url);
+
+                        Logger.info("ModelManager", "CDK assertion passed");
+                        if (onDone != null)
+                            onDone.run();
+                    } catch (McQueryVersion.McException e) {
+                        Logger.warn("ModelManager", "CDK assertion not passed, " + e.getMessage());
+                        if (doDoubleCheck)
+                            app.dialogs.popDialog("downloadDialog", (Runnable) () -> assertDownloadSource(false, onDone));
+                        else if (onDone != null)
+                            onDone.run();
+                    }
+                }
+            }.start();
+        } else {
+            Logger.info("ModelManager", "CDK assertion not passed due to not set");
+            if (doDoubleCheck)
+                app.dialogs.popDialog("downloadDialog", (Runnable) () -> assertDownloadSource(false, onDone));
+            else if (onDone != null)
+                onDone.run();
         }
     }
 }

--- a/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/RootModule.java
@@ -122,6 +122,7 @@ public final class RootModule implements Controller<ArkHomeFX> {
         app.dialogs = new DialogComposer<>(app);
         List<Node> backgroundNodes = List.of(sidebar, wrapper1, wrapper2, wrapper3);
         app.dialogs.registerDialog("announceDialog", body, backgroundNodes, "/UI/AnnounceDialog.fxml");
+        app.dialogs.registerDialog("downloadDialog", body, backgroundNodes, "/UI/DownloadDialog.fxml");
         app.dialogs.registerDialog("logDialog", body, backgroundNodes, "/UI/LogDialog.fxml");
 
         initAnnoEntrance();

--- a/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
+++ b/desktop/src/cn/harryh/arkpets/controllers/SettingsModule.java
@@ -17,9 +17,11 @@ import cn.harryh.arkpets.utils.Logger;
 import com.badlogic.gdx.graphics.Color;
 import com.jfoenix.controls.*;
 import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
 import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
+import javafx.scene.Cursor;
 import javafx.scene.control.*;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
@@ -90,10 +92,6 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
     @FXML
     private JFXButton exportLog;
     @FXML
-    private JFXTextField configNetworkAgent;
-    @FXML
-    private Label configNetworkAgentStatus;
-    @FXML
     private JFXCheckBox configAutoStartup;
     @FXML
     private JFXCheckBox configSolidExit;
@@ -103,6 +101,13 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
     private JFXButton configWindowToolwindowHelp;
     @FXML
     private JFXCheckBox configEcoMode;
+
+    @FXML
+    private JFXTextField configNetworkSource;
+    @FXML
+    private JFXTextField configNetworkProxy;
+    @FXML
+    private Label configNetworkProxyStatus;
 
     @FXML
     private Label aboutQueryUpdate;
@@ -128,6 +133,7 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
         initConfigDisplay();
         initConfigRendering();
         initConfigAdvanced();
+        initNetwork();
         initAbout();
         initScheduledListener();
 
@@ -335,29 +341,6 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
 
         exportLog.setOnMouseClicked(e -> app.dialogs.popDialog("logDialog"));
 
-        configNetworkAgent.setPromptText("示例：0.0.0.0:0");
-        configNetworkAgent.textProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue.isEmpty()) {
-                configNetworkAgentStatus.setText("未使用代理");
-                configNetworkAgentStatus.setTextFill(GuiPrefabs.COLOR_LIGHT_GRAY);
-                Logger.info("Network", "Set proxy to none");
-                setProxy("", "");
-            } else {
-                if (ipPortRegex.matcher(newValue).matches()) {
-                    String[] ipPort = newValue.split(":");
-                    setProxy(ipPort[0], ipPort[1]);
-                    configNetworkAgentStatus.setText("代理生效中");
-                    configNetworkAgentStatus.setTextFill(GuiPrefabs.COLOR_SUCCESS);
-                    Logger.info("Network", "Set proxy to host " + ipPort[0] + ", port " + ipPort[1]);
-                } else {
-                    configNetworkAgentStatus.setText("输入不合法");
-                    configNetworkAgentStatus.setTextFill(GuiPrefabs.COLOR_DANGER);
-                }
-            }
-        });
-        configNetworkAgentStatus.setText("未使用代理");
-        configNetworkAgentStatus.setTextFill(GuiPrefabs.COLOR_LIGHT_GRAY);
-
         StartupConfig startup = StartupConfig.getInstance();
         configAutoStartup.setSelected(startup.isSetStartup());
         configAutoStartup.setOnAction(e -> {
@@ -425,6 +408,39 @@ public final class SettingsModule implements Controller<ArkHomeFX> {
             app.config.eco_mode = configEcoMode.isSelected();
             app.config.save();
         });
+    }
+
+    private void initNetwork() {
+        BooleanProperty isMc = ((DownloadDialog) app.dialogs.getDialogController("downloadDialog")).getIsMcProperty();
+        isMc.addListener(observable -> configNetworkSource.setText(isMc.get() ? "Mirror 酱" : "公共源"));
+        configNetworkSource.setText(isMc.get() ? "Mirror 酱" : "公共源");
+        configNetworkSource.setEditable(false);
+        configNetworkSource.setCursor(Cursor.HAND);
+        configNetworkSource.setOnMouseClicked(e -> app.dialogs.popDialog("downloadDialog"));
+        configNetworkSource.setOnKeyPressed(e -> app.dialogs.popDialog("downloadDialog"));
+
+        configNetworkProxy.setPromptText("示例：0.0.0.0:0");
+        configNetworkProxy.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue.isEmpty()) {
+                configNetworkProxyStatus.setText("未使用代理");
+                configNetworkProxyStatus.setTextFill(GuiPrefabs.COLOR_LIGHT_GRAY);
+                Logger.info("Network", "Set proxy to none");
+                setProxy("", "");
+            } else {
+                if (ipPortRegex.matcher(newValue).matches()) {
+                    String[] ipPort = newValue.split(":");
+                    setProxy(ipPort[0], ipPort[1]);
+                    configNetworkProxyStatus.setText("代理生效中");
+                    configNetworkProxyStatus.setTextFill(GuiPrefabs.COLOR_SUCCESS);
+                    Logger.info("Network", "Set proxy to host " + ipPort[0] + ", port " + ipPort[1]);
+                } else {
+                    configNetworkProxyStatus.setText("输入不合法");
+                    configNetworkProxyStatus.setTextFill(GuiPrefabs.COLOR_DANGER);
+                }
+            }
+        });
+        configNetworkProxyStatus.setText("未使用代理");
+        configNetworkProxyStatus.setTextFill(GuiPrefabs.COLOR_LIGHT_GRAY);
     }
 
     private void initAbout() {

--- a/desktop/src/cn/harryh/arkpets/guitasks/requests/DownloadModelDatasetTask.java
+++ b/desktop/src/cn/harryh/arkpets/guitasks/requests/DownloadModelDatasetTask.java
@@ -4,18 +4,13 @@
 package cn.harryh.arkpets.guitasks.requests;
 
 import cn.harryh.arkpets.network.SourceStrategy;
-import cn.harryh.arkpets.utils.GuiPrefabs;
-import cn.harryh.arkpets.utils.IOUtils;
 import cn.harryh.arkpets.utils.Logger;
-import com.alibaba.fastjson.JSONObject;
 import javafx.scene.layout.StackPane;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 
 import static cn.harryh.arkpets.Const.PathConfig;
-import static cn.harryh.arkpets.Const.charsetDefault;
 
 
 public class DownloadModelDatasetTask extends FetchAsFileTask {
@@ -58,66 +53,5 @@ public class DownloadModelDatasetTask extends FetchAsFileTask {
 
     @Override
     protected void onDownloadedFile(File file) {
-        // When finished downloading the remote repo models info:
-        try {
-            String versionDescription;
-            try {
-                // Try to parse the remote repo models info
-                JSONObject newModelsDataset = JSONObject.parseObject(IOUtils.FileUtil.readString(file, charsetDefault));
-                versionDescription = newModelsDataset.getString("gameDataVersionDescription");
-            } catch (Exception e) {
-                // When failed to parse the remote repo models info
-                versionDescription = "unknown";
-                Logger.error("Checker", "Unable to parse remote model repo version, details see below.", e);
-                GuiPrefabs.Dialogs.createCommonDialog(parent,
-                        GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_WARNING_ALT, GuiPrefabs.COLOR_WARNING),
-                        "检查模型更新",
-                        "无法判断模型仓库版本。",
-                        "因发生错误，无法解析远程模型仓库的版本。",
-                        null).show();
-            }
-            // When finished parsing the remote models info:
-            // TODO do judgment more precisely
-            // Compare the remote models info and the local models info by their MD5
-
-            if (IOUtils.FileUtil.getMD5(new File(PathConfig.fileModelsDataPath)).equals(IOUtils.FileUtil.getMD5(new File(PathConfig.tempDirPath + PathConfig.fileModelsDataPath)))) {
-                Logger.info("Checker", "Model repo version check finished (up-to-dated)");
-                GuiPrefabs.Dialogs.createCommonDialog(parent,
-                        GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_SUCCESS_ALT, GuiPrefabs.COLOR_SUCCESS),
-                        "检查模型更新",
-                        "无需进行模型库更新。",
-                        "本地模型库的版本与远程模型库的一致。",
-                        "提示：远程模型库的版本不一定和游戏官方同步更新。\n模型库版本描述：\n" + versionDescription).show();
-            } else {
-                // If the result of comparison is "not the same"
-                String oldVersionDescription;
-                try {
-                    // Try to parse the local repo models info
-                    JSONObject oldModelsDataset = JSONObject.parseObject(IOUtils.FileUtil.readString(new File(PathConfig.fileModelsDataPath), charsetDefault));
-                    oldVersionDescription = oldModelsDataset.getString("gameDataVersionDescription");
-                } catch (Exception e) {
-                    // When failed to parse the remote local models info
-                    oldVersionDescription = "unknown";
-                    Logger.error("Checker", "Unable to parse local model repo version, details see below.", e);
-                    GuiPrefabs.Dialogs.createCommonDialog(parent,
-                            GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_WARNING_ALT, GuiPrefabs.COLOR_WARNING),
-                            "检查模型更新",
-                            "无法判断模型库版本。",
-                            "因发生错误，无法解析本地模型库的版本。",
-                            null).show();
-                }
-                GuiPrefabs.Dialogs.createCommonDialog(parent,
-                        GuiPrefabs.Icons.getIcon(GuiPrefabs.Icons.SVG_INFO_ALT, GuiPrefabs.COLOR_INFO),
-                        "检查模型更新",
-                        "模型库似乎有更新！",
-                        "您可以 [重新下载] 模型，以更新模型库版本。",
-                        "远程模型库版本描述：\n" + versionDescription + "\n\n本地模型库版本描述：\n" + oldVersionDescription).show();
-                Logger.info("Checker", "Model repo version check finished (not up-to-dated)");
-            }
-        } catch (IOException e) {
-            Logger.error("Checker", "Model repo version check failed unexpectedly, details see below.", e);
-            if (style != GuiTaskStyle.HIDDEN)
-                GuiPrefabs.Dialogs.createErrorDialog(parent, e).show();
-        }
     }
 }

--- a/desktop/src/cn/harryh/arkpets/guitasks/requests/McCheckAppUpdateTask.java
+++ b/desktop/src/cn/harryh/arkpets/guitasks/requests/McCheckAppUpdateTask.java
@@ -1,0 +1,31 @@
+/** Copyright (c) 2022-2025, Harry Huang
+ * At GPL-3.0 License
+ */
+package cn.harryh.arkpets.guitasks.requests;
+
+import com.alibaba.fastjson.JSONObject;
+import javafx.scene.layout.StackPane;
+
+
+public class McCheckAppUpdateTask extends FetchAsDataTask {
+    private final String cdk;
+
+    public McCheckAppUpdateTask(StackPane parent, GuiTaskStyle style, String cdk) {
+        super(parent, style, 16 << 20, new int[]{400, 403});  // 16 MB
+        this.cdk = cdk;
+    }
+
+    @Override
+    protected String getHeader() {
+        return "正在与 Mirror 酱建立联系";
+    }
+
+    @Override
+    protected String getRemotePath() {
+        return "https://mirrorchyan.com/api/resources/ArkPetsApp/latest?cdk=" + cdk;
+    }
+
+    @Override
+    protected void onReceivedData(JSONObject json) {
+    }
+}

--- a/desktop/src/cn/harryh/arkpets/guitasks/requests/McCheckModelsUpdateTask.java
+++ b/desktop/src/cn/harryh/arkpets/guitasks/requests/McCheckModelsUpdateTask.java
@@ -1,0 +1,31 @@
+/** Copyright (c) 2022-2025, Harry Huang
+ * At GPL-3.0 License
+ */
+package cn.harryh.arkpets.guitasks.requests;
+
+import com.alibaba.fastjson.JSONObject;
+import javafx.scene.layout.StackPane;
+
+
+public class McCheckModelsUpdateTask extends FetchAsDataTask {
+    private final String cdk;
+
+    public McCheckModelsUpdateTask(StackPane parent, GuiTaskStyle style, String cdk) {
+        super(parent, style, 4L << 30); // 4 GB
+        this.cdk = cdk;
+    }
+
+    @Override
+    protected String getHeader() {
+        return "正在与 Mirror 酱建立联系";
+    }
+
+    @Override
+    protected String getRemotePath() {
+        return "https://mirrorchyan.com/api/resources/ArkModelsRepo/latest?cdk=" + cdk;
+    }
+
+    @Override
+    protected void onReceivedData(JSONObject json) {
+    }
+}

--- a/desktop/src/cn/harryh/arkpets/network/Connections.java
+++ b/desktop/src/cn/harryh/arkpets/network/Connections.java
@@ -84,8 +84,8 @@ public class Connections {
             int len;
             byte[] bytes = new byte[httpBufferSizeDefault];
             while ((len = bis.read(bytes)) != -1) {
-                bos.write(bytes, 0, len);
                 recorder.receive(len);
+                bos.write(bytes, 0, len);
             }
             bos.flush();
         }

--- a/desktop/src/cn/harryh/arkpets/network/api/McQueryVersion.java
+++ b/desktop/src/cn/harryh/arkpets/network/api/McQueryVersion.java
@@ -1,0 +1,96 @@
+/** Copyright (c) 2022-2025, Harry Huang
+ * At GPL-3.0 License
+ */
+package cn.harryh.arkpets.network.api;
+
+import cn.harryh.arkpets.utils.Version;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+
+/** The response model for MirrorChyan query version operation.
+ *
+ * <ul>
+ *     <li>BaseURL: {@code https://mirrorchyan.com/api}</li>
+ *     <li>Endpoint: {@code /resources/{RID}/latest}</li>
+ * </ul>
+ *
+ * @see <a href="https://apifox.com/apidoc/shared/ffdc8453-597d-4ba6-bd3c-5e375c10c789/253583257e0">Apifox</a>
+ */
+public class McQueryVersion extends BaseModel<McQueryVersion.McQueryVersionData> {
+    @SuppressWarnings("unused")
+    public static class McQueryVersionData implements Serializable {
+        // The follows are always visible:
+        @JSONField
+        public String version_name;
+        @JSONField
+        public String version_number;
+        @JSONField
+        public String os;
+        @JSONField
+        public String arch;
+        @JSONField
+        public String channel;
+        @JSONField
+        public String release_note;
+
+        // The follows are visible only if provided CDK is valid:
+        @JSONField
+        public String url;
+        @JSONField
+        public long filesize;
+        @JSONField
+        public String sha256;
+        @JSONField
+        public String update_type;
+        @JSONField
+        public long cdk_expired_time;
+    }
+
+
+    @JSONField(serialize = false, deserialize = false)
+    public Version getVersion() {
+        if (data.version_name == null || data.version_name.isEmpty())
+            return null;
+        return new Version(data.version_name);
+    }
+
+    @JSONField(serialize = false, deserialize = false)
+    public Instant getCDKExpiredTime() {
+        if (data.cdk_expired_time <= 0)
+            return null;
+        return Instant.ofEpochSecond(data.cdk_expired_time);
+    }
+
+    @JSONField(serialize = false, deserialize = false)
+    public void raiseForCode() throws McException {
+        switch (code) {
+            case 0 -> {
+                // Success, do nothing
+            }
+            case 7001 -> throw new McException(code, msg, "cdk expired", "此 CDK 已经过期");
+            case 7002 -> throw new McException(code, msg, "cdk incorrect", "提供的 CDK 不正确");
+            case 7003 -> throw new McException(code, msg, "cdk exceeded usage limit", "此 CDK 已达到每日用量上限");
+            case 7004 -> throw new McException(code, msg, "cdk resource type mismatch", "此 CDK 与所下载的资源类型不匹配");
+            case 7005 -> throw new McException(code, msg, "cdk banned", "此 CDK 已经被封禁");
+            default -> throw new McException(code, msg, "unknown", "意外错误");
+        }
+    }
+
+
+    public static class McException extends Exception {
+        private final String localizedMessage;
+
+        public McException(int code, String msg, String category, String localizedCategory) {
+            super(code + " " + category + ": " + msg);
+            localizedMessage = "(" + code + ")" + localizedCategory;
+        }
+
+        @Override
+        public String getLocalizedMessage() {
+            return localizedMessage;
+        }
+    }
+}

--- a/desktop/src/cn/harryh/arkpets/utils/DialogComposer.java
+++ b/desktop/src/cn/harryh/arkpets/utils/DialogComposer.java
@@ -42,6 +42,8 @@ public class DialogComposer<T extends Application> {
      * @param onClosed A runnable callback that is executed after the dialog is closed.
      */
     public void popDialog(String dialogId, Object data, Runnable onClosed) {
+        if (!dialogs.containsKey(dialogId))
+            throw new IllegalStateException("No such dialog ID");
         DialogRecord<T> dialogRecord = dialogs.get(dialogId);
         // Avoid duplicated popup
         if (activatedDialogs.contains(dialogRecord))

--- a/desktop/src/cn/harryh/arkpets/utils/GuiPrefabs.java
+++ b/desktop/src/cn/harryh/arkpets/utils/GuiPrefabs.java
@@ -8,6 +8,7 @@ import cn.harryh.arkpets.concurrent.ProcessPool;
 import cn.harryh.arkpets.guitasks.GuiTask;
 import cn.harryh.arkpets.guitasks.ZipTask;
 import cn.harryh.arkpets.network.Connections;
+import cn.harryh.arkpets.network.api.McQueryVersion;
 import com.jfoenix.controls.*;
 import javafx.animation.FadeTransition;
 import javafx.animation.KeyFrame;
@@ -381,6 +382,9 @@ public class GuiPrefabs {
                         }
                     }
                 }
+            } else if (e instanceof McQueryVersion.McException) {
+                h2.setText("Mirror 酱拒绝了你");
+                h3.setText(e.getLocalizedMessage());
             } else if (e instanceof UnknownHostException) {
                 h2.setText("无法建立神经连接");
                 h3.setText("找不到服务器地址。可能是因为网络未连接或DNS解析失败，请尝试更换网络环境、检查防火墙和代理设置。");


### PR DESCRIPTION
### 概要

此 PR 接入了 Mirror 酱下载源，并且增加了一个**下载策略对话框**，允许用户在公共下载源和 Mirror 酱下载源之间切换。

下载策略对话框的弹出时机：

- 当用户点击模型库下载按钮，且当前下载源不是 Mirror 酱时。
- 当用户在 选项 页面中点击 下载策略 设置项时。

已接入 Mirror 酱的功能：

- 模型库检查更新（无论当前下载源是不是 Mirror 酱，都会利用 Mirror 酱进行检查更新）。
- 模型库下载（仅当下载源是 Mirror 酱时，才会利用 Mirror 酱进行下载）。

用户需要在对话框中输入 CDK，才能将下载源切换为 Mirror 酱。CDK 的本地存储采用用户-设备特异性的弱加密。

### 预览

![image](https://github.com/user-attachments/assets/dcc4b289-0d8f-4a1b-88d3-2038fb67349d)
