### PR TITLE
Fix animation matrix state

### DIFF
--- a/core/src/cn/harryh/arkpets/animations/Behavior.java
+++ b/core/src/cn/harryh/arkpets/animations/Behavior.java
@@ -18,7 +18,15 @@ abstract public class Behavior {
      */
     public Behavior() {
         actionAutoGetter = new Cached<>();
-        actionAutoGetter.setValueProducer(() -> currentMatrix.transitedAnimOf(currentState));
+        actionAutoGetter.setValueProducer(() -> {
+            StochasticState newState = currentMatrix.transitedAnimOf(currentState);
+            if (newState == null) {
+                return currentMatrix.getStateAnim(currentState);
+            } else {
+                currentState = newState;
+                return currentMatrix.getStateAnim(newState);
+            }
+        });
         actionAutoGetter.setCacheAgeProducer(() -> {
             AnimData cache = actionAutoGetter.getCachedValue();
             return cache == null ? minAnimCacheAge : Math.max(minAnimCacheAge, cache.animClip().duration);

--- a/core/src/cn/harryh/arkpets/animations/Behavior.java
+++ b/core/src/cn/harryh/arkpets/animations/Behavior.java
@@ -105,4 +105,12 @@ abstract public class Behavior {
     public AnimData dropped() {
         return new AnimData(null);
     }
+
+    public int[][] getDebugMatrix() {
+        return currentMatrix.getDebugMatrix();
+    }
+
+    public StochasticState getCurrentMatrixState() {
+        return currentState;
+    }
 }

--- a/core/src/cn/harryh/arkpets/animations/StochasticMatrix.java
+++ b/core/src/cn/harryh/arkpets/animations/StochasticMatrix.java
@@ -100,9 +100,12 @@ public class StochasticMatrix {
         return binds[state.ordinal()];
     }
 
-    public AnimData transitedAnimOf(StochasticState state) {
-        StochasticState newState = weights[state.ordinal()].random();
-        return newState == null ? binds[state.ordinal()] : binds[newState.ordinal()];
+    public StochasticState transitedAnimOf(StochasticState state) {
+        return weights[state.ordinal()].random();
+    }
+
+    public AnimData getStateAnim(StochasticState state) {
+        return binds[state.ordinal()];
     }
 
     public void bind(StochasticState state, AnimData anim) {

--- a/core/src/cn/harryh/arkpets/animations/StochasticMatrix.java
+++ b/core/src/cn/harryh/arkpets/animations/StochasticMatrix.java
@@ -130,4 +130,16 @@ public class StochasticMatrix {
                 return false;
         return true;
     }
+
+    public int[][] getDebugMatrix() {
+        int[][] matrix = new int[StochasticState.values().length][StochasticState.values().length];
+        for (int i = 0; i < weights.length; i++) {
+            StochasticMatrixRow row = weights[i];
+            for (int j=0; j < row.weights.length;j++) {
+                if(row.disabledRef[j]) matrix[i][j] = -row.weights[j];
+                else matrix[i][j] = row.weights[j];
+            }
+        }
+        return matrix;
+    }
 }


### PR DESCRIPTION
Fix the case when new state of the transited animation is null.

Add a debug matrix method.