### PR TITLE
Fix residual font file via explicit extraction

### DIFF
--- a/core/src/cn/harryh/arkpets/Const.java
+++ b/core/src/cn/harryh/arkpets/Const.java
@@ -4,14 +4,15 @@
 package cn.harryh.arkpets;
 
 import cn.harryh.arkpets.platform.HWndCtrl.NumberedTitleManager;
+import cn.harryh.arkpets.utils.IOUtils;
 import cn.harryh.arkpets.utils.Logger;
 import cn.harryh.arkpets.utils.Version;
 import javafx.util.Duration;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -126,35 +127,56 @@ public final class Const {
     }
 
 
-    /** Fonts provider class.
+    /** Fonts provider enum.
      */
-    public static class FontsConfig {
-        private static final String fontFileRegular  = "/fonts/SourceHanSansCN-Regular.otf";
-        private static final String fontFileBold     = "/fonts/SourceHanSansCN-Bold.otf";
+    public enum FontsConfig {
+        REGULAR("SourceHanSansCN-Regular.otf", 8331636),
+        BOLD("SourceHanSansCN-Bold.otf", 8543504);
 
-        public static void loadFontsToJavafx() {
+        private final String name;
+        private final int fileSize;
+
+        FontsConfig(String name, int fileSize) {
+            this.name = name;
+            this.fileSize = fileSize;
+        }
+
+        public void loadFontToJavafx() {
             if (System.getProperty("arkpets.usesystemfont") == null) {
-                javafx.scene.text.Font.loadFont(FontsConfig.class.getResourceAsStream(fontFileRegular),
-                        javafx.scene.text.Font.getDefault().getSize());
-                javafx.scene.text.Font.loadFont(FontsConfig.class.getResourceAsStream(fontFileBold),
+                javafx.scene.text.Font.loadFont(Objects.requireNonNull(extractFont()).toURI().toString(),
                         javafx.scene.text.Font.getDefault().getSize());
             }
         }
 
-        public static void loadFontsToSwing() {
+        public void loadFontToSwing() {
             if (System.getProperty("arkpets.usesystemfont") == null) {
                 try {
-                    InputStream in = Objects.requireNonNull(FontsConfig.class.getResourceAsStream(fontFileRegular));
-                    java.awt.Font font = java.awt.Font.createFont(java.awt.Font.TRUETYPE_FONT, in);
-                    if (font != null) {
-                        UIManager.put("Label.font", font.deriveFont(10f).deriveFont(Font.ITALIC));
-                        UIManager.put("Menu.font", font.deriveFont(11f));
-                        UIManager.put("MenuItem.font", font.deriveFont(11f));
-                    }
+                    File fontFile = Objects.requireNonNull(extractFont());
+                    java.awt.Font font = java.awt.Font.createFont(java.awt.Font.TRUETYPE_FONT, fontFile);
+                    UIManager.put("Label.font", font.deriveFont(10f).deriveFont(Font.ITALIC));
+                    UIManager.put("Menu.font", font.deriveFont(11f));
+                    UIManager.put("MenuItem.font", font.deriveFont(11f));
                 } catch (FontFormatException | IOException e) {
                     Logger.error("System", "Failed to load tray menu font, details see below.", e);
                 }
             }
         }
+
+        private File extractFont() {
+            try {
+                var tempFont = new File(PathConfig.tempDirPath, name);
+                if (tempFont.exists() && tempFont.length() >= fileSize)
+                    return tempFont;
+                Logger.debug("System", "Extracting font " + name + " into " + tempFont.getAbsolutePath());
+                var stream = Objects.requireNonNull(FontsConfig.class.getResourceAsStream("/fonts/" + name));
+                IOUtils.FileUtil.writeStream(tempFont, stream, false);
+                stream.close();
+                return tempFont;
+            } catch (IOException e) {
+                Logger.error("System", "Failed to extract font " + name + ", details see below.", e);
+            }
+            return null;
+        }
     }
+
 }

--- a/core/src/cn/harryh/arkpets/Const.java
+++ b/core/src/cn/harryh/arkpets/Const.java
@@ -13,6 +13,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -61,6 +62,7 @@ public final class Const {
     public static final String configExternal   = "ArkPetsConfig.json";
     public static final String configInternal   = "/ArkPetsConfigDefault.json";
     public static final String iconFilePng      = "/icons/icon.png";
+    public static final String fontDirInternal  = "/fonts/";
     // %s will be replaced by GL version (gl21, gles30)
     public static final String pass1VShader     = "shaders/%s/PlainVertex.glsl";
     public static final String pass1FShader     = "shaders/%s/PlainFragment.glsl";
@@ -164,11 +166,11 @@ public final class Const {
 
         private File extractFont() {
             try {
-                var tempFont = new File(PathConfig.tempDirPath, name);
-                if (tempFont.exists() && tempFont.length() >= fileSize)
+                File tempFont = new File(PathConfig.tempDirPath, name);
+                if (tempFont.exists() && tempFont.length() == fileSize)
                     return tempFont;
                 Logger.debug("System", "Extracting font " + name + " into " + tempFont.getAbsolutePath());
-                var stream = Objects.requireNonNull(FontsConfig.class.getResourceAsStream("/fonts/" + name));
+                InputStream stream = Objects.requireNonNull(FontsConfig.class.getResourceAsStream(fontDirInternal + name));
                 IOUtils.FileUtil.writeStream(tempFont, stream, false);
                 stream.close();
                 return tempFont;

--- a/core/src/cn/harryh/arkpets/tray/HostTray.java
+++ b/core/src/cn/harryh/arkpets/tray/HostTray.java
@@ -44,7 +44,7 @@ public class HostTray {
             } catch (Exception ignored) {
             }
         });
-        Const.FontsConfig.loadFontsToSwing();
+        Const.FontsConfig.REGULAR.loadFontToSwing();
     }
 
     public static HostTray getInstance() {

--- a/core/src/cn/harryh/arkpets/tray/MemberTray.java
+++ b/core/src/cn/harryh/arkpets/tray/MemberTray.java
@@ -31,7 +31,7 @@ public abstract class MemberTray {
             UIManager.setLookAndFeel(laf);
         } catch (Exception ignored) {
         }
-        Const.FontsConfig.loadFontsToSwing();
+        Const.FontsConfig.REGULAR.loadFontToSwing();
     }
 
     /** Initializes a tray icon instance for a ArkPets.

--- a/core/src/cn/harryh/arkpets/utils/IOUtils.java
+++ b/core/src/cn/harryh/arkpets/utils/IOUtils.java
@@ -77,6 +77,26 @@ public class IOUtils {
             writeByte(file, content.getBytes(charsetName), append);
         }
 
+        /** Writes a stream data into a file.
+         * @param file The file to write to.
+         * @param stream The specified stream to be written.
+         * @param append If false, the existed file will be overwritten; If true, content will be appended to its end.
+         * @throws IOException If I/O error occurs. It may be FileNotFoundException, etc.
+         */
+        public static void writeStream(File file, InputStream stream, boolean append) throws IOException {
+            if (!append && file.exists() && !file.delete())
+                throw new IOException("Cannot delete file:" + file.getAbsolutePath());
+            if (!file.exists() && !file.createNewFile())
+                throw new IOException("Cannot create file:" + file.getAbsolutePath());
+            FileOutputStream out = new FileOutputStream(file);
+            int index;
+            byte[] bytes = new byte[1024];
+            while ((index = stream.read(bytes)) != -1) {
+                out.write(bytes, 0, index);
+            }
+            out.close();
+        }
+
         /** Gets the MD5 checksum of the given content.
          * @param content A byte array.
          * @return MD5 hex String.

--- a/desktop/src/cn/harryh/arkpets/ArkHomeFX.java
+++ b/desktop/src/cn/harryh/arkpets/ArkHomeFX.java
@@ -56,7 +56,8 @@ public class ArkHomeFX extends Application {
     public SettingsModule settingsModule;
 
     static {
-        FontsConfig.loadFontsToJavafx();
+        FontsConfig.REGULAR.loadFontToJavafx();
+        FontsConfig.BOLD.loadFontToJavafx();
     }
 
     @Override


### PR DESCRIPTION
将字体解压到临时文件夹，避免因异常退出产生残留字体文件。