### PR TITLE
Migrate libGDX to com.amilego.gdx and upgrade to 1.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,13 @@ allprojects {
         appYearCurrent = new Date().format("yyyy", TimeZone.getTimeZone("GMT+0:00"))
         appCopyright = "Copyright (c) ${appYearBegin}-${appYearCurrent} ${appAuthor}" as GStringImpl
         // Prefabs
-        gdxVersion = "1.14.2-SNAPSHOT"
+        gdxVersion = "1.14.2"
         jnaVersion = "5.12.1"
         javaFXVersion = "17.0.15"
     }
 
     repositories {
         maven { url = "https://maven.aliyun.com/repository/public/" } // Aliyun Mirrors
-        maven { url = "https://central.sonatype.com/repository/maven-snapshots/"}
         mavenLocal()
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,14 @@ allprojects {
         appYearCurrent = new Date().format("yyyy", TimeZone.getTimeZone("GMT+0:00"))
         appCopyright = "Copyright (c) ${appYearBegin}-${appYearCurrent} ${appAuthor}" as GStringImpl
         // Prefabs
-        gdxVersion = "1.11.0"
+        gdxVersion = "1.14.2-SNAPSHOT"
         jnaVersion = "5.12.1"
         javaFXVersion = "17.0.15"
     }
 
     repositories {
         maven { url = "https://maven.aliyun.com/repository/public/" } // Aliyun Mirrors
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/"}
         mavenLocal()
         mavenCentral()
     }
@@ -45,7 +46,7 @@ project(":desktop") {
     dependencies {
         implementation project(":core")
         // libGDX Desktop
-        api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+        api "com.amilego.gdx:gdx-platform:$gdxVersion:natives-desktop"
     }
 }
 
@@ -55,9 +56,9 @@ project(":core") {
         // Spine Runtime
         api "com.esotericsoftware.spine:spine-libgdx:3.8.99.1"
         // libGDX
-        api "com.badlogicgames.gdx:gdx:$gdxVersion"
-        api "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-        api "com.badlogicgames.gdx:gdx-lwjgl3-angle:$gdxVersion"
+        api "com.amilego.gdx:gdx:$gdxVersion"
+        api "com.amilego.gdx:gdx-backend-lwjgl3:$gdxVersion"
+        api "com.amilego.gdx:gdx-lwjgl3-angle:$gdxVersion"
         // JNA
         api "net.java.dev.jna:jna:$jnaVersion"
         api "net.java.dev.jna:jna-platform:$jnaVersion"

--- a/core/src/cn/harryh/arkpets/ArkChar.java
+++ b/core/src/cn/harryh/arkpets/ArkChar.java
@@ -124,7 +124,7 @@ public class ArkChar {
         skeleton.updateWorldTransform();
         // 4.Animation setup
         AnimationStateData asd = new AnimationStateData(skeletonData);
-        animList = new AnimClipGroup(skeletonData.getAnimations().toArray(Animation.class));
+        animList = new AnimClipGroup(skeletonData.getAnimations());
         // 5.Animation state setup
         animationState = new AnimationState(asd);
         animationState.apply(skeleton);

--- a/core/src/cn/harryh/arkpets/animations/AnimClipGroup.java
+++ b/core/src/cn/harryh/arkpets/animations/AnimClipGroup.java
@@ -18,15 +18,15 @@ import java.util.*;
 public class AnimClipGroup implements Collection<AnimClip> {
     protected final ArrayList<AnimClip> animClipList;
 
-    public AnimClipGroup(Animation[] animList) {
+    public AnimClipGroup(Iterable<Animation> animations) {
         this.animClipList = new ArrayList<>();
-        for (Animation a : animList)
+        for (Animation a : animations)
             this.animClipList.add(new AnimClip(a));
         sortStages();
     }
 
-    protected AnimClipGroup(Collection<AnimClip> animClipList) {
-        this.animClipList = new ArrayList<>(animClipList);
+    protected AnimClipGroup(Collection<AnimClip> animClips) {
+        this.animClipList = new ArrayList<>(animClips);
     }
 
     /** Finds the animations that match the given type.

--- a/core/src/cn/harryh/arkpets/utils/InputApplicationAdaptor.java
+++ b/core/src/cn/harryh/arkpets/utils/InputApplicationAdaptor.java
@@ -197,6 +197,12 @@ abstract public class InputApplicationAdaptor extends ApplicationAdapter impleme
 
     @Deprecated
     @Override
+    public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
+        return touchUp(screenX, screenY, pointer, button);
+    }
+
+    @Deprecated
+    @Override
     public boolean mouseMoved(int screenX, int screenY) {
         int dx = screenX - mouseX;
         int dy = screenY - mouseY;


### PR DESCRIPTION
## Summary

This PR migrates the libGDX dependencies from `com.badlogicgames.gdx` to `com.amilego.gdx` coordinate. For more details, please check [AmiLego/libgdx](https://github.com/AmiLego/libgdx) repository.

This PR also upgrades the version of libGDX from 1.11.0 to 1.14.2. For more details, please read [this blog](https://blog.harryh.cn/Programming/LibGDX-Changelog-1110-To-1142/). After upgrading, we observed a significant improvement of top 1% frame latency.
